### PR TITLE
Add miniscript for funding transaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2018"
 anyhow = "1"
 bitcoin = { version = "0.23.0", features = ["rand", "use-serde"] }
 conquer-once = "0.2"
+hex = "0.4.2"
+miniscript = {version = "1.0.0", features = ["compiler"]}

--- a/src/create.rs
+++ b/src/create.rs
@@ -57,7 +57,8 @@ impl Party0 {
         let TX_f = FundingTransaction::new(
             (x_self.public(), tid_self.clone()),
             (X_other, tid_other.clone()),
-        );
+        )
+        .expect(todo!("Should we use anyhow everywhere?"));
 
         Party1 {
             x_self,


### PR DESCRIPTION
For now we use `and(x_0, x_1)` - eventually we might want to replace this with a threshold signature