### PR TITLE
Implement descriptor for Commitment transaction.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ bitcoin = { version = "0.23.0", features = ["rand", "use-serde"] }
 conquer-once = "0.2"
 hex = "0.4.2"
 miniscript = { version = "1.0.0", features = ["compiler"] }
+thiserror = "1"

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,6 +1,7 @@
 use conquer_once::Lazy;
 
 pub use bitcoin::secp256k1::{PublicKey, SecretKey};
+use std::fmt;
 
 pub static SECP: Lazy<bitcoin::secp256k1::Secp256k1<bitcoin::secp256k1::All>> =
     Lazy::new(bitcoin::secp256k1::Secp256k1::new);
@@ -29,6 +30,15 @@ impl KeyPair {
     }
 }
 
+impl From<SecretKey> for KeyPair {
+    fn from(secret_key: SecretKey) -> Self {
+        Self {
+            secret_key,
+            public_key: PublicKey::from_secret_key(&SECP, &secret_key),
+        }
+    }
+}
+
 pub struct RevocationKeyPair(KeyPair);
 pub struct RevocationPublicKey(PublicKey);
 
@@ -44,6 +54,18 @@ impl RevocationKeyPair {
     }
 }
 
+impl From<PublicKey> for RevocationPublicKey {
+    fn from(public_key: PublicKey) -> Self {
+        Self(public_key)
+    }
+}
+
+impl From<RevocationPublicKey> for PublicKey {
+    fn from(r_public_key: RevocationPublicKey) -> Self {
+        r_public_key.0
+    }
+}
+
 pub struct PublishingKeyPair(KeyPair);
 pub struct PublishingPublicKey(PublicKey);
 
@@ -56,5 +78,35 @@ impl PublishingKeyPair {
 
     pub fn public(&self) -> PublishingPublicKey {
         PublishingPublicKey(self.0.public_key)
+    }
+}
+
+impl From<SecretKey> for PublishingKeyPair {
+    fn from(secret_key: SecretKey) -> Self {
+        Self(secret_key.into())
+    }
+}
+
+impl From<PublicKey> for PublishingPublicKey {
+    fn from(public_key: PublicKey) -> Self {
+        Self(public_key)
+    }
+}
+
+impl From<PublishingPublicKey> for PublicKey {
+    fn from(p_public_key: PublishingPublicKey) -> Self {
+        p_public_key.0
+    }
+}
+
+impl fmt::LowerHex for PublishingPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:x}", self.0)
+    }
+}
+
+impl fmt::Display for PublishingPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -9,6 +9,8 @@ use bitcoin::{
 use miniscript::Segwitv0;
 use std::str::FromStr;
 
+pub type Result<T> = std::result::Result<T, Error>;
+
 #[derive(Clone)]
 pub struct FundingTransaction(Transaction);
 
@@ -50,7 +52,7 @@ impl FundingTransaction {
     pub fn descriptor(
         X_self: &secp256k1::PublicKey,
         X_other: &secp256k1::PublicKey,
-    ) -> anyhow::Result<miniscript::Descriptor<bitcoin::PublicKey>> {
+    ) -> Result<miniscript::Descriptor<bitcoin::PublicKey>> {
         // Describes the spending policy of the channel fund transaction T_f.
         // For now we use `and(x_self, x_other)` - eventually we might want to replace this with a threshold signature.
         const MINISCRIPT_TEMPLATE: &str = "c:and_v(v:pk(X_self),pk_k(X_other))";
@@ -75,12 +77,14 @@ pub struct CommitTransaction {
 }
 
 impl CommitTransaction {
-    // TODO: Handle expiry by passing it as an argument
     pub fn new(
         TX_f: &FundingTransaction,
-        (_X_0, _R_0, _Y_0): (PublicKey, RevocationPublicKey, PublishingPublicKey),
-        (_X_1, _R_1, _Y_1): (PublicKey, RevocationPublicKey, PublishingPublicKey),
-    ) -> Self {
+        (X_0, R_0, Y_0): (PublicKey, RevocationPublicKey, PublishingPublicKey),
+        (X_1, R_1, Y_1): (PublicKey, RevocationPublicKey, PublishingPublicKey),
+        time_lock: u32,
+    ) -> Result<Self> {
+        let descriptor = Self::descriptor((X_0, R_0, Y_0), (X_1, R_1, Y_1), time_lock)?;
+
         let input = TX_f.as_txin();
         let transaction = Transaction {
             version: 2,
@@ -90,14 +94,11 @@ impl CommitTransaction {
             // spending conditions
             output: vec![TxOut {
                 value: TX_f.value().as_sat(),
-                script_pubkey: todo!(
-                    "Use Miniscript to generate the transaction output with three
-                 spending conditions using (X_0, R_0, Y_0) and (X_1, R_1, Y_1)"
-                ),
+                script_pubkey: descriptor.script_pubkey(),
             }],
         };
 
-        Self { inner: transaction }
+        Ok(Self { inner: transaction })
     }
 
     /// Sign the commit transaction.
@@ -132,6 +133,39 @@ impl CommitTransaction {
         let sighash_all = 1;
         self.inner
             .signature_hash(0, &descriptor.witness_script(), sighash_all)
+    }
+
+    fn descriptor(
+        (X_0, R_0, Y_0): (PublicKey, RevocationPublicKey, PublishingPublicKey),
+        (X_1, R_1, Y_1): (PublicKey, RevocationPublicKey, PublishingPublicKey),
+        time_lock: u32,
+    ) -> Result<miniscript::Descriptor<bitcoin::PublicKey>> {
+        let X_0 = hex::encode(X_0.serialize().to_vec());
+        let R_0 = hex::encode(Into::<PublicKey>::into(R_0).serialize().to_vec());
+        let Y_0 = hex::encode(Into::<PublicKey>::into(Y_0).serialize().to_vec());
+        let X_1 = hex::encode(X_1.serialize().to_vec());
+        let R_1 = hex::encode(Into::<PublicKey>::into(R_1).serialize().to_vec());
+        let Y_1 = hex::encode(Into::<PublicKey>::into(Y_1).serialize().to_vec());
+
+        // Describes the spending policy of the channel commit transaction T_c.
+        // There are possible way to spend this transaction:
+        // 1. Channel state: It is correctly signed w.r.t pk_0, pk_1 and after relative timelock
+        // 2. Punish 0: It is correctly signed w.r.t pk_1, Y_0, R_0
+        // 3. Punish 1: It is correctly signed w.r.t pk_0, Y_1, R_1
+        // TODO: Make an explicit choice between using `tresh` or composing `or` and `and` (which are both binary operators)
+        let channel_state_condition =
+            format!("and(older({}),and(pk({}),pk({})))", time_lock, X_0, X_1);
+        let punish_0_condition = format!("and(pk({}),and(pk({}),pk({})))", X_1, Y_0, R_0);
+        let punish_1_condition = format!("and(pk({}),and(pk({}),pk({})))", X_0, Y_1, R_1);
+        let descriptor_str = format!(
+            "or({},or({},{}))",
+            channel_state_condition, punish_0_condition, punish_1_condition
+        );
+        let policy = miniscript::policy::Concrete::<bitcoin::PublicKey>::from_str(&descriptor_str)?;
+        let miniscript = policy.compile()?;
+        let descriptor = miniscript::Descriptor::Wsh(miniscript);
+
+        Ok(descriptor)
     }
 }
 
@@ -197,6 +231,14 @@ impl SplitTransaction {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Miniscript compiler: ")]
+    MiniscriptCompiler(#[from] miniscript::policy::compiler::CompilerError),
+    #[error("Miniscript: ")]
+    Miniscript(#[from] miniscript::Error),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,7 +258,7 @@ mod tests {
     }
 
     #[test]
-    fn descriptor_to_witness_script() {
+    fn funding_descriptor_to_witness_script() {
         let X_0 = secp256k1::PublicKey::from_str(
             "0218845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
         )
@@ -229,5 +271,44 @@ mod tests {
 
         let witness_script = format!("{}", descriptor.witness_script());
         assert_eq!(witness_script, "Script(OP_PUSHBYTES_33 0218845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166 OP_CHECKSIGVERIFY OP_PUSHBYTES_33 022222222222222222222222222222222222222222222222222222222222222222 OP_CHECKSIG)");
+    }
+
+    #[test]
+    fn commitment_descriptor_to_witness_script() {
+        let X_0 = secp256k1::PublicKey::from_str(
+            "032a34617a9141231baa27bcadf622322eed1e16b6036fdf15f42a85f7250c4823",
+        )
+        .unwrap();
+        let R_0 = secp256k1::PublicKey::from_str(
+            "03ff65a7fedd9dc637bbaf3cbe4c5971de853e0c359195f19c57211fe0b96ab39e",
+        )
+        .unwrap()
+        .into();
+        let Y_0 = secp256k1::PublicKey::from_str(
+            "03b3ee07bb851fec17e6cdb2dc235523555dc3193c2ff6399ef28ce941bc57b2b4",
+        )
+        .unwrap()
+        .into();
+        let X_1 = secp256k1::PublicKey::from_str(
+            "03437a3813f17a264e2c8fc41fb0895634d34c7c9cb9147c553cc67ff37293b1cd",
+        )
+        .unwrap();
+        let R_1 = secp256k1::PublicKey::from_str(
+            "02b637ba109a2a844b27d31c9ffac41bfe080d2f0256eeb03839d66442c4ce0deb",
+        )
+        .unwrap()
+        .into();
+        let Y_1 = secp256k1::PublicKey::from_str(
+            "03851562dd136d68ff0911b4aa6b1ec95850144ddb939a1070159f0a4163d20895",
+        )
+        .unwrap()
+        .into();
+        let time_lock = 144;
+
+        let descriptor =
+            CommitTransaction::descriptor((X_0, R_0, Y_0), (X_1, R_1, Y_1), time_lock).unwrap();
+
+        let witness_script = format!("{}", descriptor.witness_script());
+        assert_eq!(witness_script, "Script(OP_IF OP_PUSHBYTES_33 032a34617a9141231baa27bcadf622322eed1e16b6036fdf15f42a85f7250c4823 OP_CHECKSIGVERIFY OP_PUSHBYTES_33 03437a3813f17a264e2c8fc41fb0895634d34c7c9cb9147c553cc67ff37293b1cd OP_CHECKSIGVERIFY OP_PUSHBYTES_2 9000 OP_CSV OP_ELSE OP_IF OP_DUP OP_HASH160 OP_PUSHBYTES_20 635de934904ad5406559beebcc3ca0d119721323 OP_EQUALVERIFY OP_CHECKSIGVERIFY OP_DUP OP_HASH160 OP_PUSHBYTES_20 be60bbce0058cb25f268d70559e1a3433d75f557 OP_EQUALVERIFY OP_CHECKSIGVERIFY OP_DUP OP_HASH160 OP_PUSHBYTES_20 4c8a3449333f92f386b4b8a202353719016261e8 OP_EQUALVERIFY OP_ELSE OP_DUP OP_HASH160 OP_PUSHBYTES_20 1b08ea4a2fbbe0121205f63068f78564ff204995 OP_EQUALVERIFY OP_CHECKSIGVERIFY OP_DUP OP_HASH160 OP_PUSHBYTES_20 ea92d4bb15b4babd0c216c12f61fe7083ed06e3b OP_EQUALVERIFY OP_CHECKSIGVERIFY OP_DUP OP_HASH160 OP_PUSHBYTES_20 565dd1650db6ffae1c2dd67d83a5709aa0ddd2e9 OP_EQUALVERIFY OP_ENDIF OP_CHECKSIG OP_ENDIF)");
     }
 }


### PR DESCRIPTION
Do note that `and` and `or` are binary operators. I went for a quick and dirty usage of `thresh`,
we may want to think more about it and possibly use `and(A,and(B,C))` instead.