### PR TITLE
Ignore unused clippy and unreachable code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ anyhow = "1"
 bitcoin = { version = "0.23.0", features = ["rand", "use-serde"] }
 conquer-once = "0.2"
 hex = "0.4.2"
-miniscript = {version = "1.0.0", features = ["compiler"]}
+miniscript = { version = "1.0.0", features = ["compiler"] }

--- a/src/create.rs
+++ b/src/create.rs
@@ -6,8 +6,8 @@ use crate::{
     transaction::{CommitTransaction, FundingTransaction, SplitTransaction},
     ChannelState,
 };
-use bitcoin::{secp256k1, Amount, TxIn};
 use anyhow::Context;
+use bitcoin::{secp256k1, Amount, TxIn};
 
 pub struct Message0 {
     X: PublicKey,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(non_snake_case,unused,unreachable_code)]
+#![allow(non_snake_case, unused, unreachable_code)]
 
 pub mod create;
 mod keys;


### PR DESCRIPTION
To make the build clean I "temporarily" ignore some clippy warnings. We just have to remember to re-enable them again.

* `unsed`: some fields/functions are unused at the moment
* `unreachable`: everything after a `todo!` is unreachable 