### PR TITLE
Setup the test to open a channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,15 @@ on:
 
 jobs:
   static_analysis:
-    env:
-      RUST_TOOLCHAIN: nightly
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install ${{ env.RUST_TOOLCHAIN }} toolchain
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
           components: rustfmt, clippy
 
@@ -44,26 +41,15 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
 
   build_test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        rust_toolchain: [nightly ]
-        continue_on_error: [false]
-        include:
-          - os: ubuntu-latest
-            rust_toolchain: nightly
-            continue_on_error: true
-    continue-on-error: ${{ matrix.continue_on_error }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install ${{ matrix.rust_toolchain }} toolchain
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust_toolchain }}
           override: true
 
       - name: Cache target directory

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ thiserror = "1"
 [dev-dependencies]
 bitcoin-harness = { git = "https://github.com/coblox/bitcoin-harness-rs.git", rev = "974cbf078815d24b199a3d1d8d0b2c189218eaea" }
 testcontainers = "0.9"
+tokio = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ miniscript = { version = "1.0.0", features = ["compiler"] }
 rand = "0.7"
 sha2 = "0.9"
 thiserror = "1"
+
+[dev-dependencies]
+bitcoin-harness = { git = "https://github.com/coblox/bitcoin-harness-rs.git", rev = "974cbf078815d24b199a3d1d8d0b2c189218eaea" }
+testcontainers = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,39 @@
+//! # Thor
+//!
+//! A proof of concept of the paper: `Generalized Bitcoin-compatible channels` on top of Bitcoin.
+//!
+//! # Examples
+//!
+//! ## Open a channel
+//!
+//! ```rust
+//! use bitcoin_harness::{Bitcoind, bitcoind_rpc, Client, Wallet};
+//!
+//! # #[tokio::main]
+//! # async fn main() {
+//! // Setting up a Bitcoin regtest environment
+//! let tc_client = testcontainers::clients::Cli::default();
+//! let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
+//! let client = Client::new(bitcoind.node_url.clone());
+//! bitcoind.init(5).await.unwrap();
+//!
+//! let alice_wallet = Wallet::new("alice_wallet", bitcoind.node_url.clone()).await.unwrap();
+//! {
+//!     let address = alice_wallet.new_address().await.unwrap();
+//!     let amount = bitcoin::Amount::from_btc(3.0).unwrap();
+//!     bitcoind.mint(address, amount).await.unwrap();
+//! }
+//!
+//! let bob_wallet = Wallet::new("alice_wallet", bitcoind.node_url.clone()).await.unwrap();
+//! {
+//!     let address = bob_wallet.new_address().await.unwrap();
+//!     let amount = bitcoin::Amount::from_btc(3.0).unwrap();
+//!     bitcoind.mint(address, amount).await.unwrap();
+//! }
+//!
+//! # }
+//! ```
+
 #![allow(non_snake_case, unused, unreachable_code)]
 
 pub mod create;


### PR DESCRIPTION
As this is a PoC to showcase the implementation of
the Generalized Bitcoin-compatible channels, the showcasing
is highlight by being part of the lib documentation. 

TODO:
Please take over this PR. I have implemented `list_unspent` on the harness wallet with https://github.com/coblox/bitcoin-harness-rs/pull/4.
This should allow to get a `TxIn` to do `Party::new`. You may want to update the harness to deserialize `Unspent.amount` directly in `bitcoin::Amount` instead of an `f64`.

Also need to deactivate macos for the CI as it does not support docker and adds little value to this lib.