### PR TITLE
Model first two states differently per party

### DIFF
--- a/src/create.rs
+++ b/src/create.rs
@@ -37,23 +37,15 @@ pub struct Message4 {
     TX_f_signed_once: FundingTransaction,
 }
 
-struct Alice;
-struct Bob;
-
-pub struct Party0<R> {
+pub struct Alice0 {
     x_self: KeyPair,
     tid_self: (TxIn, Amount),
-    phantom: PhantomData<R>,
 }
 
-impl Party0<Alice> {
+impl Alice0 {
     pub fn new(tid_self: (TxIn, Amount)) -> Self {
         let x_self = KeyPair::new_random();
-        Self {
-            x_self,
-            tid_self,
-            phantom: Default::default(),
-        }
+        Self { x_self, tid_self }
     }
 
     pub fn next_message(&self) -> Message0 {
@@ -69,7 +61,7 @@ impl Party0<Alice> {
             X: X_other,
             tid: tid_other,
         }: Message0,
-    ) -> anyhow::Result<Party1<Alice>> {
+    ) -> anyhow::Result<Alice1> {
         let TX_f = FundingTransaction::new(
             (self.x_self.public(), self.tid_self.clone()),
             (X_other, tid_other.clone()),
@@ -78,7 +70,7 @@ impl Party0<Alice> {
 
         let r = RevocationKeyPair::new_random();
         let y = PublishingKeyPair::new_random();
-        Ok(Party1 {
+        Ok(Alice1 {
             x_self: self.x_self,
             X_other,
             tid_self: self.tid_self,
@@ -86,19 +78,19 @@ impl Party0<Alice> {
             r_self: r,
             y_self: y,
             TX_f,
-            phantom: PhantomData::default(),
         })
     }
 }
 
-impl Party0<Bob> {
+pub struct Bob0 {
+    x_self: KeyPair,
+    tid_self: (TxIn, Amount),
+}
+
+impl Bob0 {
     pub fn new(tid_self: (TxIn, Amount)) -> Self {
         let x_self = KeyPair::new_random();
-        Self {
-            x_self,
-            tid_self,
-            phantom: Default::default(),
-        }
+        Self { x_self, tid_self }
     }
 
     pub fn next_message(&self) -> Message0 {
@@ -114,7 +106,7 @@ impl Party0<Bob> {
             X: X_other,
             tid: tid_other,
         }: Message0,
-    ) -> anyhow::Result<Party1<Bob>> {
+    ) -> anyhow::Result<Bob1> {
         let TX_f = FundingTransaction::new(
             (X_other, tid_other.clone()),
             (self.x_self.public(), self.tid_self.clone()),
@@ -123,7 +115,7 @@ impl Party0<Bob> {
 
         let r = RevocationKeyPair::new_random();
         let y = PublishingKeyPair::new_random();
-        Ok(Party1 {
+        Ok(Bob1 {
             x_self: self.x_self,
             X_other,
             tid_self: self.tid_self,
@@ -131,12 +123,11 @@ impl Party0<Bob> {
             r_self: r,
             y_self: y,
             TX_f,
-            phantom: PhantomData::default(),
         })
     }
 }
 
-pub struct Party1<R> {
+pub struct Alice1 {
     x_self: KeyPair,
     X_other: PublicKey,
     tid_self: (TxIn, Amount),
@@ -144,10 +135,9 @@ pub struct Party1<R> {
     r_self: RevocationKeyPair,
     y_self: PublishingKeyPair,
     TX_f: FundingTransaction,
-    phantom: PhantomData<R>,
 }
 
-impl Party1<Alice> {
+impl Alice1 {
     pub fn next_message(&self) -> Message1 {
         Message1 {
             R: self.r_self.public(),
@@ -205,7 +195,17 @@ impl Party1<Alice> {
     }
 }
 
-impl Party1<Bob> {
+pub struct Bob1 {
+    x_self: KeyPair,
+    X_other: PublicKey,
+    tid_self: (TxIn, Amount),
+    tid_other: (TxIn, Amount),
+    r_self: RevocationKeyPair,
+    y_self: PublishingKeyPair,
+    TX_f: FundingTransaction,
+}
+
+impl Bob1 {
     pub fn next_message(&self) -> Message1 {
         Message1 {
             R: self.r_self.public(),

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -9,6 +9,7 @@ pub static SECP: Lazy<bitcoin::secp256k1::Secp256k1<bitcoin::secp256k1::All>> =
 // TODO: Consider using libsecp256k1 instead of bitcoin::secp256k1 (or
 // even secp256k1FUN!), like we did in A2L. That way we can get rid of
 // the `static SECP`, among other things
+#[derive(Clone)]
 pub struct KeyPair {
     secret_key: SecretKey,
     public_key: PublicKey,
@@ -67,6 +68,8 @@ impl From<RevocationPublicKey> for PublicKey {
 }
 
 pub struct PublishingKeyPair(KeyPair);
+
+#[derive(Clone, Copy)]
 pub struct PublishingPublicKey(PublicKey);
 
 impl PublishingKeyPair {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,6 @@ use crate::keys::PublicKey;
 use bitcoin::Amount;
 
 pub struct ChannelState {
-    party_0: (Amount, PublicKey),
-    party_1: (Amount, PublicKey),
+    a: (Amount, PublicKey),
+    b: (Amount, PublicKey),
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,5 +1,6 @@
 use crate::{
-    keys::{PublicKey, PublishingPublicKey, RevocationPublicKey},
+    create::AdaptorSignature,
+    keys::{KeyPair, PublicKey, PublishingPublicKey, RevocationPublicKey},
     ChannelState,
 };
 use anyhow::Context;
@@ -14,8 +15,14 @@ use std::str::FromStr;
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Clone)]
-pub struct FundingTransaction(Transaction);
+pub struct FundingTransaction {
+    inner: Transaction,
+    output_descriptor: miniscript::Descriptor<bitcoin::PublicKey>,
+}
 
+// TODO: We assume that the FundingTransaction only has one output,
+// but this is probably not true as both parties will likely include
+// change outputs
 impl FundingTransaction {
     // A `bitcoin::TxIn` does not include the amount, it just
     // references the `previous_output`'s `TxId` and `vout`. There may
@@ -24,24 +31,27 @@ impl FundingTransaction {
         (X_a, (tid_a, amount_a)): (PublicKey, (TxIn, Amount)),
         (X_b, (tid_b, amount_b)): (PublicKey, (TxIn, Amount)),
     ) -> anyhow::Result<Self> {
-        let descriptor =
-            FundingTransaction::descriptor(&X_a, &X_b).context("failed to build descriptor")?;
+        let output_descriptor = FundingTransaction::build_descriptor(&X_a, &X_b)
+            .context("failed to build descriptor")?;
         let transaction = Transaction {
             version: 2,
             lock_time: 0,
             input: vec![tid_a, tid_b],
             output: vec![TxOut {
                 value: (amount_a + amount_b).as_sat(),
-                script_pubkey: descriptor.script_pubkey(),
+                script_pubkey: output_descriptor.script_pubkey(),
             }],
         };
 
-        Ok(Self(transaction))
+        Ok(Self {
+            inner: transaction,
+            output_descriptor,
+        })
     }
 
     pub fn as_txin(&self) -> TxIn {
         TxIn {
-            previous_output: OutPoint::new(self.0.txid(), 0),
+            previous_output: OutPoint::new(self.inner.txid(), 0),
             script_sig: Script::new(),
             sequence: 0xFFFF_FFFF,
             witness: Vec::new(),
@@ -49,10 +59,14 @@ impl FundingTransaction {
     }
 
     pub fn value(&self) -> Amount {
-        Amount::from_sat(self.0.output[0].value)
+        Amount::from_sat(self.inner.output[0].value)
     }
 
-    pub fn descriptor(
+    pub fn output_descriptor(&self) -> miniscript::Descriptor<bitcoin::PublicKey> {
+        self.output_descriptor.clone()
+    }
+
+    fn build_descriptor(
         X_a: &secp256k1::PublicKey,
         X_b: &secp256k1::PublicKey,
     ) -> Result<miniscript::Descriptor<bitcoin::PublicKey>> {
@@ -75,18 +89,20 @@ impl FundingTransaction {
     }
 }
 
+#[derive(Clone)]
 pub struct CommitTransaction {
     inner: Transaction,
+    digest: SigHash,
 }
 
 impl CommitTransaction {
     pub fn new(
         TX_f: &FundingTransaction,
-        (X_0, R_0, Y_0): (PublicKey, RevocationPublicKey, PublishingPublicKey),
-        (X_1, R_1, Y_1): (PublicKey, RevocationPublicKey, PublishingPublicKey),
+        (X_a, R_a, Y_a): (PublicKey, RevocationPublicKey, PublishingPublicKey),
+        (X_b, R_b, Y_b): (PublicKey, RevocationPublicKey, PublishingPublicKey),
         time_lock: u32,
     ) -> Result<Self> {
-        let descriptor = Self::descriptor((X_0, R_0, Y_0), (X_1, R_1, Y_1), time_lock)?;
+        let descriptor = Self::descriptor((X_a, R_a, Y_a), (X_b, R_b, Y_b), time_lock)?;
 
         let input = TX_f.as_txin();
         let transaction = Transaction {
@@ -101,18 +117,29 @@ impl CommitTransaction {
             }],
         };
 
-        Ok(Self { inner: transaction })
+        let digest = Self::compute_digest(&transaction, TX_f);
+
+        Ok(Self {
+            inner: transaction,
+            digest,
+        })
     }
 
-    /// Sign the commit transaction.
-    ///
-    /// Each party must ensure that they pass the arguments in the
-    /// same order that they did when calling
-    /// `FundingTransaction::new`.
-    pub fn sign(
+    pub fn sign_once(
+        &self,
+        _x_self: KeyPair,
+        _Y_other: PublishingPublicKey,
+    ) -> anyhow::Result<AdaptorSignature> {
+        let sig = todo!("pSign self.digest with x_self and Y_other");
+
+        Ok(sig)
+    }
+
+    /// Add signatures to CommitTransaction.
+    pub fn add_signatures(
         self,
-        (_X_0, _sig_0): (PublicKey, secp256k1::Signature),
-        (_X_1, _sig_1): (PublicKey, secp256k1::Signature),
+        (_X_a, _sig_a): (PublicKey, secp256k1::Signature),
+        (_X_b, _sig_b): (PublicKey, secp256k1::Signature),
     ) -> anyhow::Result<Self> {
         // NOTE: Could return a `SignedCommitTransaction` for extra type
         // safety.
@@ -132,10 +159,21 @@ impl CommitTransaction {
         Amount::from_sat(self.inner.output[0].value)
     }
 
-    pub fn digest(&self, descriptor: miniscript::Descriptor<bitcoin::PublicKey>) -> SigHash {
+    pub fn digest(&self) -> SigHash {
+        self.digest
+    }
+
+    fn compute_digest(
+        commit_transaction: &Transaction,
+        funding_transaction: &FundingTransaction,
+    ) -> SigHash {
+        let input_index = 0;
         let sighash_all = 1;
-        self.inner
-            .signature_hash(0, &descriptor.witness_script(), sighash_all)
+        commit_transaction.signature_hash(
+            input_index,
+            &funding_transaction.output_descriptor().witness_script(),
+            sighash_all,
+        )
     }
 
     fn descriptor(
@@ -197,21 +235,21 @@ impl SplitTransaction {
     pub fn new(
         TX_c: &CommitTransaction,
         ChannelState {
-            party_0: (amount_0, X_0),
-            party_1: (amount_1, X_1),
+            a: (amount_a, X_a),
+            b: (amount_b, X_b),
         }: ChannelState,
     ) -> Self {
         let input = TX_c.as_txin();
 
-        let descriptor = SplitTransaction::wpk_descriptor(X_0);
-        let output_0 = TxOut {
-            value: amount_0.as_sat(),
+        let descriptor = SplitTransaction::wpk_descriptor(X_a);
+        let output_a = TxOut {
+            value: amount_a.as_sat(),
             script_pubkey: descriptor.script_pubkey(),
         };
 
-        let descriptor = SplitTransaction::wpk_descriptor(X_1);
-        let output_1 = TxOut {
-            value: amount_1.as_sat(),
+        let descriptor = SplitTransaction::wpk_descriptor(X_b);
+        let output_b = TxOut {
+            value: amount_b.as_sat(),
             script_pubkey: descriptor.script_pubkey(),
         };
 
@@ -219,7 +257,7 @@ impl SplitTransaction {
             version: 2,
             lock_time: 0,
             input: vec![input.clone()],
-            output: vec![output_0, output_1],
+            output: vec![output_a, output_b],
         };
 
         let digest = SighashComponents::new(&transaction).sighash_all(
@@ -235,6 +273,12 @@ impl SplitTransaction {
             inner: transaction,
             digest,
         }
+    }
+
+    pub fn sign_once(&self, _x_self: KeyPair) -> anyhow::Result<secp256k1::Signature> {
+        let sig = todo!("Sign self.digest with x_self");
+
+        Ok(sig)
     }
 
     fn wpk_descriptor(key: PublicKey) -> miniscript::Descriptor<bitcoin::PublicKey> {
@@ -286,7 +330,7 @@ mod tests {
             "022222222222222222222222222222222222222222222222222222222222222222",
         )
         .expect("key 1");
-        let descriptor = FundingTransaction::descriptor(&X_0, &X_1).unwrap();
+        let descriptor = FundingTransaction::build_descriptor(&X_0, &X_1).unwrap();
 
         let witness_script = format!("{}", descriptor.witness_script());
         assert_eq!(witness_script, "Script(OP_PUSHBYTES_33 0218845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166 OP_CHECKSIGVERIFY OP_PUSHBYTES_33 022222222222222222222222222222222222222222222222222222222222222222 OP_CHECKSIG)");


### PR DESCRIPTION
Because the order of the arguments when building the descriptors matters.