### PR TITLE
Punish protocol e2e test

### DIFF
--- a/src/punish.rs
+++ b/src/punish.rs
@@ -11,6 +11,13 @@ pub struct Party0 {
 pub struct NotOldCommitTransaction;
 
 impl Party0 {
+    pub fn new(x_self: OwnershipKeyPair, revoked_states: Vec<RevokedState>) -> Self {
+        Self {
+            x_self,
+            revoked_states,
+        }
+    }
+
     pub fn punish(&self, transaction: Transaction) -> anyhow::Result<PunishTransaction> {
         let RevokedState {
             channel_state:

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -246,11 +246,28 @@ impl CommitTransaction {
         Ok(TX_c)
     }
 
-    pub fn as_txin(&self) -> TxIn {
+    /// Use `CommitTransaction` as a Transaction Input for the
+    /// `SplitTransaction`. The sequence number is set to the value of
+    /// `time_lock` since the `SplitTransaction` uses the
+    /// time-locked path of the `CommitTransaction`'s script.
+    pub fn as_txin_for_TX_s(&self) -> TxIn {
         TxIn {
             previous_output: OutPoint::new(self.inner.txid(), 0),
             script_sig: Script::new(),
             sequence: self.time_lock,
+            witness: Vec::new(),
+        }
+    }
+
+    /// Use `CommitTransaction` as a Transaction Input for the
+    /// `PunishTransaction`. The sequence number is set to `OxFFFF_FFFF` since
+    /// the `PunishTransaction` does not use the time-locked path of the
+    /// `CommitTransaction`'s script.
+    pub fn as_txin_for_TX_p(&self) -> TxIn {
+        TxIn {
+            previous_output: OutPoint::new(self.inner.txid(), 0),
+            script_sig: Script::new(),
+            sequence: 0xFFFF_FFFF,
             witness: Vec::new(),
         }
     }
@@ -353,7 +370,7 @@ impl SplitTransaction {
             b: (amount_b, X_b),
         } = channel_balance.clone();
 
-        let input = TX_c.as_txin();
+        let input = TX_c.as_txin_for_TX_s();
 
         // TODO: Maybe we should spend directly to an address owned by the wallet
 
@@ -460,7 +477,7 @@ impl SplitTransaction {
 
     fn compute_digest(TX_s: &Transaction, TX_c: &CommitTransaction) -> SigHash {
         SighashComponents::new(&TX_s).sighash_all(
-            &TX_c.as_txin(),
+            &TX_c.as_txin_for_TX_s(),
             &TX_c.output_descriptor().witness_script(),
             TX_c.value().as_sat(),
         )
@@ -520,15 +537,15 @@ impl PunishTransaction {
             .ok_or_else(|| PunishError::RecoveryFailure)?;
 
         let mut TX_p = {
-            let output_descriptor = SplitTransaction::wpk_descriptor(x_self.public());
+            let output_descriptor = PunishTransaction::wpk_descriptor(x_self.public());
             let output = TxOut {
-                value: TX_c.value().as_sat(),
+                value: TX_c.value().as_sat() - 10_000,
                 script_pubkey: output_descriptor.script_pubkey(),
             };
             Transaction {
                 version: 2,
                 lock_time: 0,
-                input: vec![TX_c.as_txin()],
+                input: vec![TX_c.as_txin_for_TX_p()],
                 output: vec![output],
             }
         };
@@ -586,13 +603,26 @@ impl PunishTransaction {
     }
 
     fn compute_digest(TX_p: &Transaction, TX_c: &CommitTransaction) -> SigHash {
-        let input_index = 0;
-        let sighash_all = 1;
-        TX_p.signature_hash(
-            input_index,
+        SighashComponents::new(&TX_p).sighash_all(
+            &TX_c.as_txin_for_TX_p(),
             &TX_c.output_descriptor().witness_script(),
-            sighash_all,
+            TX_c.value().as_sat(),
         )
+    }
+
+    fn wpk_descriptor(key: OwnershipPublicKey) -> miniscript::Descriptor<bitcoin::PublicKey> {
+        let pk = bitcoin::PublicKey {
+            key: key.into(),
+            compressed: true,
+        };
+
+        miniscript::Descriptor::Wpkh(pk)
+    }
+}
+
+impl From<PunishTransaction> for Transaction {
+    fn from(from: PunishTransaction) -> Self {
+        from.0
     }
 }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -5,7 +5,7 @@ mod harness;
 use bitcoin::Amount;
 use bitcoin_harness::{self, Bitcoind};
 use harness::{create, update};
-use thor::update::ChannelUpdate;
+use thor::{punish, update::ChannelUpdate};
 
 #[tokio::test]
 async fn e2e_channel_creation() {
@@ -50,8 +50,6 @@ async fn e2e_channel_update() {
 
     let create::Final { alice, bob } = create::run(&alice_wallet, alice, &bob_wallet, bob).await;
 
-    assert_eq!(alice.signed_TX_f, bob.signed_TX_f);
-
     alice_wallet
         .0
         .send_raw_transaction(alice.signed_TX_f.clone())
@@ -79,4 +77,55 @@ async fn e2e_channel_update() {
         bob.balance().unwrap().theirs,
         Amount::from_btc(0.5).unwrap()
     );
+}
+
+#[tokio::test]
+async fn e2e_punish_publication_of_revoked_commit_transaction() {
+    let tc_client = testcontainers::clients::Cli::default();
+    let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
+
+    let time_lock = 1;
+    let (alice_balance, bob_balance) = (Amount::ONE_BTC, Amount::ONE_BTC);
+
+    let create::Init {
+        alice,
+        alice_wallet,
+        bob,
+        bob_wallet,
+    } = create::Init::new(&bitcoind, alice_balance, bob_balance, time_lock).await;
+
+    let create::Final { alice, bob } = create::run(&alice_wallet, alice, &bob_wallet, bob).await;
+
+    alice_wallet
+        .0
+        .send_raw_transaction(alice.signed_TX_f.clone())
+        .await
+        .unwrap();
+
+    let update::Init { alice, bob } = update::Init::new(alice, bob);
+
+    let channel_update = ChannelUpdate::Pay(Amount::from_btc(0.5).unwrap());
+    let time_lock = 1;
+
+    let update::Final { alice, bob } = update::run(alice, bob, channel_update, time_lock);
+
+    // Alice attempts to cheat by publishing a revoked commit transaction
+
+    let signed_revoked_TX_c = alice.latest_revoked_signed_TX_c().unwrap().unwrap();
+    alice_wallet
+        .0
+        .send_raw_transaction(signed_revoked_TX_c.clone())
+        .await
+        .unwrap();
+
+    // Bob sees the transaction and punishes Alice
+
+    let bob = punish::Party0::from(bob);
+    let TX_p = bob.punish(signed_revoked_TX_c).unwrap();
+
+    bob_wallet
+        .0
+        .send_raw_transaction(TX_p.into())
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
We don't verify a wallet balance because the output is actually owned by Bob's `OwnershipKeyPair` generated by the protocol. We could either spend from that output or modify the protocols to handle a "final_address" owned by a party's wallet.