### PR TITLE
Make `Channel` a common struct representing the channel current state. Attempt to improve terminology.

### DIFF
--- a/src/create.rs
+++ b/src/create.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     signature::{verify_encsig, verify_sig},
     transaction::{CommitTransaction, FundOutput, SplitTransaction},
-    ChannelBalance,
+    SplitOutputs,
 };
 use anyhow::Context;
 use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount, Transaction};
@@ -289,7 +289,7 @@ impl Alice2 {
         )?;
         let encsig_TX_c_self = TX_c.encsign_once(self.x_self.clone(), Y_other.clone());
 
-        let TX_s = SplitTransaction::new(&TX_c, ChannelBalance {
+        let TX_s = SplitTransaction::new(&TX_c, SplitOutputs {
             a: (self.TX_f.amount_a(), self.x_self.public()),
             b: (self.TX_f.amount_b(), self.X_other.clone()),
         });
@@ -347,7 +347,7 @@ impl Bob2 {
         )?;
         let encsig_TX_c_self = TX_c.encsign_once(self.x_self.clone(), Y_other.clone());
 
-        let TX_s = SplitTransaction::new(&TX_c, ChannelBalance {
+        let TX_s = SplitTransaction::new(&TX_c, SplitOutputs {
             a: (self.TX_f.amount_a(), self.X_other.clone()),
             b: (self.TX_f.amount_b(), self.x_self.public()),
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub struct RevokedState {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct ChannelBalance {
+pub struct SplitOutputs {
     a: (Amount, OwnershipPublicKey),
     b: (Amount, OwnershipPublicKey),
 }
@@ -86,16 +86,16 @@ impl Channel {
     }
 
     pub fn balance(&self) -> anyhow::Result<LocalBalance> {
-        let channel_balance = self.current_state.signed_TX_s.balance();
+        let outputs = self.current_state.signed_TX_s.outputs();
 
-        match channel_balance {
-            ChannelBalance {
+        match outputs {
+            SplitOutputs {
                 a: (ours, X_a),
                 b: (theirs, X_b),
             } if X_a == self.x_self.public() && X_b == self.X_other => {
                 Ok(LocalBalance { ours, theirs })
             }
-            ChannelBalance {
+            SplitOutputs {
                 a: (theirs, X_a),
                 b: (ours, X_b),
             } if X_a == self.X_other && X_b == self.x_self.public() => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,10 @@ mod transaction;
 pub mod update;
 
 use crate::{
-    keys::{OwnershipPublicKey, PublishingKeyPair, RevocationKeyPair},
-    transaction::{CommitTransaction, SplitTransaction},
+    keys::{OwnershipKeyPair, OwnershipPublicKey, PublishingKeyPair, RevocationKeyPair},
+    transaction::{CommitTransaction, FundingTransaction, SplitTransaction},
 };
+use anyhow::bail;
 use bitcoin::Amount;
 use ecdsa_fun::adaptor::EncryptedSignature;
 use keys::{PublishingPublicKey, RevocationPublicKey, RevocationSecretKey};
@@ -48,4 +49,59 @@ pub struct RevokedState {
 pub struct ChannelBalance {
     a: (Amount, OwnershipPublicKey),
     b: (Amount, OwnershipPublicKey),
+}
+
+pub struct Channel {
+    x_self: OwnershipKeyPair,
+    X_other: OwnershipPublicKey,
+    TX_f_body: FundingTransaction,
+    current_state: ChannelState,
+    revoked_states: Vec<RevokedState>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct LocalBalance {
+    pub ours: Amount,
+    pub theirs: Amount,
+}
+
+impl Channel {
+    pub fn new(party: create::Party6) -> Self {
+        Self {
+            x_self: party.x_self,
+            X_other: party.X_other,
+            TX_f_body: party.TX_f_body,
+            current_state: ChannelState {
+                TX_c: party.TX_c,
+                encsig_TX_c_self: party.encsig_TX_c_self,
+                encsig_TX_c_other: party.encsig_TX_c_other,
+                r_self: party.r_self,
+                R_other: party.R_other,
+                y_self: party.y_self,
+                Y_other: party.Y_other,
+                signed_TX_s: party.signed_TX_s,
+            },
+            revoked_states: Vec::new(),
+        }
+    }
+
+    pub fn balance(&self) -> anyhow::Result<LocalBalance> {
+        let channel_balance = self.current_state.signed_TX_s.balance();
+
+        match channel_balance {
+            ChannelBalance {
+                a: (ours, X_a),
+                b: (theirs, X_b),
+            } if X_a == self.x_self.public() && X_b == self.X_other => {
+                Ok(LocalBalance { ours, theirs })
+            }
+            ChannelBalance {
+                a: (theirs, X_a),
+                b: (ours, X_b),
+            } if X_a == self.X_other && X_b == self.x_self.public() => {
+                Ok(LocalBalance { ours, theirs })
+            }
+            _ => bail!("split transaction does not pay to X_self and X_other"),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub struct Channel {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct LocalBalance {
+pub struct Balance {
     pub ours: Amount,
     pub theirs: Amount,
 }
@@ -85,22 +85,18 @@ impl Channel {
         }
     }
 
-    pub fn balance(&self) -> anyhow::Result<LocalBalance> {
+    pub fn balance(&self) -> anyhow::Result<Balance> {
         let outputs = self.current_state.signed_TX_s.outputs();
 
         match outputs {
             SplitOutputs {
                 a: (ours, X_a),
                 b: (theirs, X_b),
-            } if X_a == self.x_self.public() && X_b == self.X_other => {
-                Ok(LocalBalance { ours, theirs })
-            }
+            } if X_a == self.x_self.public() && X_b == self.X_other => Ok(Balance { ours, theirs }),
             SplitOutputs {
                 a: (theirs, X_a),
                 b: (ours, X_b),
-            } if X_a == self.X_other && X_b == self.x_self.public() => {
-                Ok(LocalBalance { ours, theirs })
-            }
+            } if X_a == self.X_other && X_b == self.x_self.public() => Ok(Balance { ours, theirs }),
             _ => bail!("split transaction does not pay to X_self and X_other"),
         }
     }

--- a/src/punish.rs
+++ b/src/punish.rs
@@ -48,7 +48,7 @@ mod test {
         keys::{PublishingKeyPair, RevocationKeyPair},
         signature::decrypt,
         transaction::{input_psbt, CommitTransaction, FundingTransaction, SplitTransaction},
-        ChannelBalance,
+        SplitOutputs,
     };
     use bitcoin::Amount;
 
@@ -83,7 +83,7 @@ mod test {
         )
         .unwrap();
 
-        let TX_s = SplitTransaction::new(&TX_c, ChannelBalance {
+        let TX_s = SplitTransaction::new(&TX_c, SplitOutputs {
             a: (channel_balance_alice, x_alice.public()),
             b: (channel_balance_bob, x_bob.public()),
         });

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -3,7 +3,7 @@ use crate::{
         OwnershipKeyPair, OwnershipPublicKey, PublishingKeyPair, PublishingPublicKey,
         RevocationKeyPair, RevocationPublicKey,
     },
-    ChannelBalance,
+    SplitOutputs,
 };
 use anyhow::bail;
 use bitcoin::{
@@ -343,15 +343,15 @@ pub struct SplitTransaction {
     inner: Transaction,
     input_descriptor: Descriptor<bitcoin::PublicKey>,
     digest: SigHash,
-    balance: ChannelBalance,
+    outputs: SplitOutputs,
 }
 
 impl SplitTransaction {
-    pub fn new(TX_c: &CommitTransaction, channel_balance: ChannelBalance) -> Self {
-        let ChannelBalance {
+    pub fn new(TX_c: &CommitTransaction, outputs: SplitOutputs) -> Self {
+        let SplitOutputs {
             a: (amount_a, X_a),
             b: (amount_b, X_b),
-        } = channel_balance.clone();
+        } = outputs.clone();
 
         let input = TX_c.as_txin();
 
@@ -384,7 +384,7 @@ impl SplitTransaction {
             inner: TX_s,
             input_descriptor,
             digest,
-            balance: channel_balance,
+            outputs,
         }
     }
 
@@ -392,8 +392,8 @@ impl SplitTransaction {
         x_self.sign(self.digest)
     }
 
-    pub fn balance(&self) -> ChannelBalance {
-        self.balance.clone()
+    pub fn outputs(&self) -> SplitOutputs {
+        self.outputs.clone()
     }
 
     pub fn digest(&self) -> SigHash {

--- a/src/update.rs
+++ b/src/update.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     signature::{verify_encsig, verify_sig},
     transaction::{CommitTransaction, FundingTransaction, SplitTransaction},
-    Channel, ChannelBalance, ChannelState, LocalBalance, RevokedState,
+    Channel, ChannelState, LocalBalance, RevokedState, SplitOutputs,
 };
 use anyhow::{bail, Context};
 use bitcoin::Amount;
@@ -129,7 +129,7 @@ impl State0 {
         )?;
         let encsig_TX_c_self = TX_c.encsign_once(channel.x_self.clone(), Y_other.clone());
 
-        let TX_s = SplitTransaction::new(&TX_c, ChannelBalance {
+        let TX_s = SplitTransaction::new(&TX_c, SplitOutputs {
             a: (balance_other, channel.X_other.clone()),
             b: (balance_self, channel.x_self.public()),
         });
@@ -198,7 +198,7 @@ impl AliceState0 {
             alice: balance_self,
             bob: balance_other,
         } = self.proposed_balance;
-        let TX_s = SplitTransaction::new(&TX_c, ChannelBalance {
+        let TX_s = SplitTransaction::new(&TX_c, SplitOutputs {
             a: (balance_self, self.x_self.public()),
             b: (balance_other, self.X_other.clone()),
         });
@@ -487,7 +487,7 @@ mod test {
         )
         .unwrap();
 
-        let TX_s = SplitTransaction::new(&TX_c, ChannelBalance {
+        let TX_s = SplitTransaction::new(&TX_c, SplitOutputs {
             a: (current_balance.alice, x_alice.public()),
             b: (current_balance.bob, x_bob.public()),
         });

--- a/src/update.rs
+++ b/src/update.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     signature::{verify_encsig, verify_sig},
     transaction::{CommitTransaction, FundingTransaction, SplitTransaction},
-    Channel, ChannelState, LocalBalance, RevokedState, SplitOutputs,
+    Channel, ChannelState, RevokedState, SplitOutputs,
 };
 use anyhow::{bail, Context};
 use bitcoin::Amount;
@@ -65,7 +65,7 @@ impl State0 {
     ) -> anyhow::Result<(AliceState0, ChannelUpdateProposal)> {
         let channel = self.0;
 
-        let LocalBalance { ours, theirs } = channel.balance()?;
+        let crate::Balance { ours, theirs } = channel.balance()?;
         let proposed_balance = Balance {
             alice: ours,
             bob: theirs,

--- a/tests/harness/update.rs
+++ b/tests/harness/update.rs
@@ -1,55 +1,53 @@
 use thor::{update, update::ChannelUpdate};
 
 pub struct Init {
-    pub alice: update::Party0,
-    pub bob: update::Party0,
+    pub alice: update::Channel,
+    pub bob: update::Channel,
 }
 
 impl Init {
     pub fn new(alice: thor::create::Party6, bob: thor::create::Party6) -> Self {
-        let alice = update::Party0::new(alice);
-        let bob = update::Party0::new(bob);
+        let alice = update::Channel::new(alice);
+        let bob = update::Channel::new(bob);
 
         Self { alice, bob }
     }
 }
 
 pub struct Final {
-    pub alice: update::Party0,
-    pub bob: update::Party0,
+    pub alice: update::Channel,
+    pub bob: update::Channel,
 }
 
 pub fn run(
-    alice0: update::Party0,
-    bob0: update::Party0,
+    alice0: update::Channel,
+    bob0: update::Channel,
     channel_update: ChannelUpdate,
     time_lock: u32,
 ) -> Final {
-    let (alice1, message0) = alice0
-        .propose_channel_update(channel_update, time_lock)
-        .unwrap();
+    let (alice1, message0) = alice0.compose(channel_update, time_lock).unwrap();
 
-    let (bob1, message1) = bob0.receive_channel_update(message0).unwrap();
+    let (bob1, message1) = bob0.interpret(message0).unwrap();
 
-    let alice2 = alice1.receive(message1).unwrap();
+    let alice2 = alice1.interpret(message1).unwrap();
 
-    let message2_alice = alice2.next_message();
-    let message2_bob = bob1.next_message();
+    let message2_alice = alice2.compose();
+    let message2_bob = bob1.compose();
 
-    let alice3 = alice2.receive(message2_bob).unwrap();
-    let bob2 = bob1.receive(message2_alice).unwrap();
+    let alice3 = alice2.interpret(message2_bob).unwrap();
+    let bob2 = bob1.interpret(message2_alice).unwrap();
 
-    let message3_alice = alice3.next_message();
-    let message3_bob = bob2.next_message();
+    let message3_alice = alice3.compose();
+    let message3_bob = bob2.compose();
 
-    let alice4 = alice3.receive(message3_bob).unwrap();
-    let bob3 = bob2.receive(message3_alice).unwrap();
+    let alice4 = alice3.interpret(message3_bob).unwrap();
+    let bob3 = bob2.interpret(message3_alice).unwrap();
 
-    let message4_alice = alice4.next_message();
-    let message4_bob = bob3.next_message();
+    let message4_alice = alice4.compose();
+    let message4_bob = bob3.compose();
 
-    let alice5 = alice4.receive(message4_bob).unwrap();
-    let bob4 = bob3.receive(message4_alice).unwrap();
+    let alice5 = alice4.interpret(message4_bob).unwrap();
+    let bob4 = bob3.interpret(message4_alice).unwrap();
 
     Final {
         alice: alice5,

--- a/tests/harness/update.rs
+++ b/tests/harness/update.rs
@@ -1,30 +1,33 @@
-use thor::{update, update::ChannelUpdate};
+use thor::{update, update::ChannelUpdate, Channel};
 
 pub struct Init {
-    pub alice: update::Channel,
-    pub bob: update::Channel,
+    pub alice: Channel,
+    pub bob: Channel,
 }
 
 impl Init {
     pub fn new(alice: thor::create::Party6, bob: thor::create::Party6) -> Self {
-        let alice = update::Channel::new(alice);
-        let bob = update::Channel::new(bob);
+        let alice = Channel::new(alice);
+        let bob = Channel::new(bob);
 
         Self { alice, bob }
     }
 }
 
 pub struct Final {
-    pub alice: update::Channel,
-    pub bob: update::Channel,
+    pub alice: Channel,
+    pub bob: Channel,
 }
 
 pub fn run(
-    alice0: update::Channel,
-    bob0: update::Channel,
+    alice_channel: Channel,
+    bob_channel: Channel,
     channel_update: ChannelUpdate,
     time_lock: u32,
 ) -> Final {
+    let alice0: update::State0 = alice_channel.into();
+    let bob0: update::State0 = bob_channel.into();
+
     let (alice1, message0) = alice0.compose(channel_update, time_lock).unwrap();
 
     let (bob1, message1) = bob0.interpret(message0).unwrap();


### PR DESCRIPTION
- Move `Channel` to `lib.rs`
- Lots of bold renaming, please review by patch and check the commit message for justification.