### PR TITLE
Make create and update protocols symmetric

### DIFF
--- a/thor/Cargo.toml
+++ b/thor/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
+arrayvec = "0.5"
 async-trait = "0.1"
 base64 = "0.12"
 bitcoin = { version = "0.23.0", features = ["rand"] }
@@ -13,7 +14,7 @@ conquer-once = "0.2"
 ecdsa_fun = { git = "https://github.com/LLFourn/secp256kfun", branch = "thor", features = ["libsecp_compat"] }
 enum-as-inner = "0.3"
 futures = "0.3"
-hex = "0.4.2"
+hex = "0.4"
 miniscript = { version = "1.0.0", features = ["compiler"] }
 rand = "0.7"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/thor/src/keys.rs
+++ b/thor/src/keys.rs
@@ -45,6 +45,12 @@ impl OwnershipKeyPair {
     }
 }
 
+impl PartialOrd for OwnershipPublicKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.0.to_bytes().cmp(&other.0.to_bytes()))
+    }
+}
+
 impl From<Point> for OwnershipPublicKey {
     fn from(public_key: Point) -> Self {
         Self(public_key)

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -205,7 +205,7 @@ impl Channel {
     {
         let state0 = close::State0::new(&self);
 
-        let msg0_self = state0.compose();
+        let msg0_self = state0.compose()?;
         transport.send_message(Message::Close0(msg0_self)).await?;
 
         let msg0_other = map_err(transport.receive_message().await?.into_close0())?;

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -14,25 +14,23 @@
 #![forbid(unsafe_code)]
 #![allow(non_snake_case)]
 
+#[cfg(feature = "serde")]
+pub(crate) mod serde;
+
 mod keys;
-pub mod protocols;
+mod protocols;
 mod signature;
 mod transaction;
 
 pub use ::bitcoin;
-
-#[cfg(feature = "serde")]
-pub(crate) mod serde;
+pub use protocols::create::{BuildFundingPSBT, SignFundingPSBT};
 
 use crate::{
     keys::{
         OwnershipKeyPair, OwnershipPublicKey, PublishingKeyPair, PublishingPublicKey,
         RevocationKeyPair, RevocationPublicKey, RevocationSecretKey,
     },
-    protocols::{
-        create::{BuildFundingPSBT, SignFundingPSBT},
-        punish::punish,
-    },
+    protocols::punish::punish,
     transaction::{CommitTransaction, FundingTransaction, SplitTransaction},
 };
 use bitcoin::{Address, Amount, Transaction, Txid};
@@ -59,6 +57,11 @@ pub struct Channel {
 }
 
 #[async_trait::async_trait]
+pub trait NewAddress {
+    async fn new_address(&self) -> anyhow::Result<Address>;
+}
+
+#[async_trait::async_trait]
 pub trait BroadcastSignedTransaction {
     async fn broadcast_signed_transaction(&self, transaction: Transaction) -> anyhow::Result<()>;
 }
@@ -74,15 +77,16 @@ pub trait ReceiveMessage {
 }
 
 impl Channel {
-    /// Create a channel in the role of Alice.
+    /// Create a channel.
     ///
-    /// The `fund_amount` represents how much Bitcoin Alice will contribute to
-    /// the channel. Bob will contribute the _same_ amount as Alice.
+    /// The `fund_amount` represents how much Bitcoin either party will
+    /// contribute to the channel. This means both parties contribute the same
+    /// amount.
     ///
     /// Consumers should implement the traits `SendMessage` and `ReceiveMessage`
-    /// on the `transport` they provide, allowing Alice to communicate with
-    /// Bob.
-    pub async fn create_alice<T, W>(
+    /// on the `transport` they provide, allowing the parties to communicate
+    /// with each other.
+    pub async fn create<T, W>(
         transport: &mut T,
         wallet: &W,
         fund_amount: Amount,
@@ -93,80 +97,26 @@ impl Channel {
         T: SendMessage + ReceiveMessage,
     {
         let final_address = wallet.new_address().await?;
-        let alice0 = create::Alice0::new(fund_amount, time_lock, final_address);
+        let state0 = create::State0::new(fund_amount, time_lock, final_address);
 
-        let msg0_alice = alice0.next_message();
-        transport.send_message(Message::Create0(msg0_alice)).await?;
+        let msg0_self = state0.next_message();
+        transport.send_message(Message::Create0(msg0_self)).await?;
 
-        let msg0_bob = map_err(transport.receive_message().await?.into_create0())?;
-        let alice1 = alice0.receive(msg0_bob, wallet).await?;
+        let msg0_other = map_err(transport.receive_message().await?.into_create0())?;
+        let state1 = state0.receive(msg0_other, wallet).await?;
 
-        let msg1_alice = alice1.next_message();
-        transport.send_message(Message::Create1(msg1_alice)).await?;
+        let msg1_self = state1.next_message();
+        transport.send_message(Message::Create1(msg1_self)).await?;
 
-        let msg1_bob = map_err(transport.receive_message().await?.into_create1())?;
-        let alice2 = alice1.receive(msg1_bob)?;
+        let msg1_other = map_err(transport.receive_message().await?.into_create1())?;
+        let state2 = state1.receive(msg1_other)?;
 
-        let msg2_alice = alice2.next_message();
-        transport.send_message(Message::Create2(msg2_alice)).await?;
+        let msg2_self = state2.next_message();
+        transport.send_message(Message::Create2(msg2_self)).await?;
 
-        let msg2_bob = map_err(transport.receive_message().await?.into_create2())?;
+        let msg2_other = map_err(transport.receive_message().await?.into_create2())?;
+        let state3 = state2.receive(msg2_other)?;
 
-        let alice3 = alice2.receive(msg2_bob)?;
-
-        Self::create(transport, wallet, alice3).await
-    }
-
-    /// Create a channel in the role of Bob.
-    ///
-    /// The `fund_amount` represents how much Bitcoin Bob will contribute to
-    /// the channel. Alice will contribute the _same_ amount as Bob.
-    ///
-    /// Consumers should implement the traits `SendMessage` and `ReceiveMessage`
-    /// on the `transport` they provide, allowing Bob to communicate with Alice.
-    pub async fn create_bob<T, W>(
-        transport: &mut T,
-        wallet: &W,
-        fund_amount: Amount,
-        time_lock: u32,
-    ) -> anyhow::Result<Self>
-    where
-        W: BuildFundingPSBT + SignFundingPSBT + BroadcastSignedTransaction + NewAddress,
-        T: SendMessage + ReceiveMessage,
-    {
-        let final_address = wallet.new_address().await?;
-        let bob0 = create::Bob0::new(fund_amount, time_lock, final_address);
-
-        let msg0_bob = bob0.next_message();
-        transport.send_message(Message::Create0(msg0_bob)).await?;
-
-        let msg0_alice = map_err(transport.receive_message().await?.into_create0())?;
-        let bob1 = bob0.receive(msg0_alice, wallet).await?;
-
-        let msg1_bob = bob1.next_message();
-        transport.send_message(Message::Create1(msg1_bob)).await?;
-
-        let msg1_alice = map_err(transport.receive_message().await?.into_create1())?;
-        let bob2 = bob1.receive(msg1_alice)?;
-
-        let msg2_bob = bob2.next_message();
-        transport.send_message(Message::Create2(msg2_bob)).await?;
-
-        let msg2_alice = map_err(transport.receive_message().await?.into_create2())?;
-        let bob3 = bob2.receive(msg2_alice)?;
-
-        Self::create(transport, wallet, bob3).await
-    }
-
-    async fn create<W, T>(
-        transport: &mut T,
-        wallet: &W,
-        state3: create::Party3,
-    ) -> anyhow::Result<Self>
-    where
-        W: BuildFundingPSBT + SignFundingPSBT + BroadcastSignedTransaction,
-        T: SendMessage + ReceiveMessage,
-    {
         let msg3_self = state3.next_message();
         transport.send_message(Message::Create3(msg3_self)).await?;
 
@@ -191,7 +141,16 @@ impl Channel {
         Ok(channel)
     }
 
-    pub async fn update_alice<T>(
+    /// Update the distribution of coins in the channel.
+    ///
+    /// It assumes that the counterparty has already agreed to update the
+    /// channel with the `new_balance` and the same `timelock` and will call
+    /// the same API (or an equivalent one).
+    ///
+    /// Consumers should implement the traits `SendMessage` and `ReceiveMessage`
+    /// on the `transport` they provide, allowing the parties to communicate
+    /// with each other.
+    pub async fn update<T>(
         &mut self,
         transport: &mut T,
         new_balance: Balance,
@@ -200,41 +159,14 @@ impl Channel {
     where
         T: SendMessage + ReceiveMessage,
     {
-        let alice0 = update::Alice0::new(self.clone(), new_balance, time_lock);
+        let state0 = update::State0::new(self.clone(), new_balance, time_lock);
 
-        let msg0_alice = alice0.compose();
-        transport.send_message(Message::Update0(msg0_alice)).await?;
+        let msg0_self = state0.compose();
+        transport.send_message(Message::Update0(msg0_self)).await?;
 
-        let msg0_bob = map_err(transport.receive_message().await?.into_update0())?;
-        let alice1 = alice0.interpret(msg0_bob)?;
+        let msg0_other = map_err(transport.receive_message().await?.into_update0())?;
+        let state1 = state0.interpret(msg0_other)?;
 
-        self.update(transport, alice1).await
-    }
-
-    pub async fn update_bob<T>(
-        &mut self,
-        transport: &mut T,
-        new_balance: Balance,
-        time_lock: u32,
-    ) -> anyhow::Result<()>
-    where
-        T: SendMessage + ReceiveMessage,
-    {
-        let bob0 = update::Bob0::new(self.clone(), new_balance, time_lock);
-
-        let msg0_bob = bob0.compose();
-        transport.send_message(Message::Update0(msg0_bob)).await?;
-
-        let msg0_alice = map_err(transport.receive_message().await?.into_update0())?;
-        let bob1 = bob0.interpret(msg0_alice)?;
-
-        self.update(transport, bob1).await
-    }
-
-    async fn update<T>(&mut self, transport: &mut T, state1: update::State1) -> anyhow::Result<()>
-    where
-        T: SendMessage + ReceiveMessage,
-    {
         let msg1_self = state1.compose();
         transport.send_message(Message::Update1(msg1_self)).await?;
 
@@ -258,9 +190,14 @@ impl Channel {
         Ok(())
     }
 
-    /// Close the channel collaboratively. It assumes that the counterparty has
-    /// already agreed to close the channel and will call the same API (or an
-    /// equivalent one).
+    /// Close the channel collaboratively.
+    ///
+    /// It assumes that the counterparty has already agreed to close the channel
+    /// and will call the same API (or an equivalent one).
+    ///
+    /// Consumers should implement the traits `SendMessage` and `ReceiveMessage`
+    /// on the `transport` they provide, allowing the parties to communicate
+    /// with each other.
     pub async fn close<T, W>(&mut self, transport: &mut T, wallet: &W) -> anyhow::Result<()>
     where
         T: SendMessage + ReceiveMessage,
@@ -358,18 +295,18 @@ pub struct ChannelState {
     /// broadcast `TX_c`, we will be able to extract their `PublishingSecretKey`
     /// by using `recover_decryption_key`. If said `TX_c` was already revoked,
     /// we can use it with the `RevocationSecretKey` to punish them.
-    pub encsig_TX_c_self: EncryptedSignature,
+    encsig_TX_c_self: EncryptedSignature,
     /// Encrypted signature received from the counterparty. It can be decrypted
     /// using our `PublishingSecretkey` and used to sign `TX_c`. Keep in mind,
     /// that publishing a revoked `TX_c` will allow the counterparty to punish
     /// us.
-    pub encsig_TX_c_other: EncryptedSignature,
+    encsig_TX_c_other: EncryptedSignature,
     r_self: RevocationKeyPair,
     R_other: RevocationPublicKey,
     y_self: PublishingKeyPair,
     Y_other: PublishingPublicKey,
     /// Signed split transaction.
-    pub signed_TX_s: SplitTransaction,
+    signed_TX_s: SplitTransaction,
 }
 
 impl ChannelState {
@@ -436,11 +373,6 @@ pub struct Balance {
         serde(with = "bitcoin::util::amount::serde::as_sat")
     )]
     pub theirs: Amount,
-}
-
-#[async_trait::async_trait]
-pub trait NewAddress {
-    async fn new_address(&self) -> anyhow::Result<Address>;
 }
 
 /// All possible messages that can be sent between two parties using this

--- a/thor/src/protocols/create.rs
+++ b/thor/src/protocols/create.rs
@@ -66,7 +66,7 @@ pub struct Message5 {
 }
 
 #[derive(Debug)]
-pub struct Alice0 {
+pub struct State0 {
     x_self: OwnershipKeyPair,
     final_address_self: Address,
     fund_amount_self: Amount,
@@ -82,7 +82,7 @@ pub trait BuildFundingPSBT {
     ) -> anyhow::Result<PartiallySignedTransaction>;
 }
 
-impl Alice0 {
+impl State0 {
     pub fn new(fund_amount: Amount, time_lock: u32, final_address: Address) -> Self {
         let x_self = OwnershipKeyPair::new_random();
 
@@ -112,13 +112,14 @@ impl Alice0 {
             time_lock: time_lock_other,
         }: Message0,
         wallet: &impl BuildFundingPSBT,
-    ) -> anyhow::Result<Alice1> {
+    ) -> anyhow::Result<State1> {
         // NOTE: A real application would also verify that the amount
         // provided by the other party is satisfactory, together with
         // the time_lock
         check_timelocks(self.time_lock, time_lock_other)?;
 
-        let fund_output = FundOutput::new(self.x_self.public(), X_other.clone());
+        let fund_output = FundOutput::new([self.x_self.public(), X_other.clone()]);
+        dbg!(&fund_output);
         let tid_self = wallet
             .build_funding_psbt(fund_output.address(), self.fund_amount_self)
             .await?;
@@ -128,7 +129,7 @@ impl Alice0 {
             theirs: fund_amount_other,
         };
 
-        Ok(Alice1 {
+        Ok(State1 {
             x_self: self.x_self,
             X_other,
             final_address_self: self.final_address_self,
@@ -136,164 +137,6 @@ impl Alice0 {
             balance,
             tid_self,
             time_lock: self.time_lock,
-        })
-    }
-}
-
-#[derive(Debug)]
-pub struct Bob0 {
-    x_self: OwnershipKeyPair,
-    final_address_self: Address,
-    fund_amount_self: Amount,
-    time_lock: u32,
-}
-
-impl Bob0 {
-    pub fn new(fund_amount: Amount, time_lock: u32, final_address: Address) -> Self {
-        let x_self = OwnershipKeyPair::new_random();
-
-        Self {
-            x_self,
-            final_address_self: final_address,
-            fund_amount_self: fund_amount,
-            time_lock,
-        }
-    }
-
-    pub fn next_message(&self) -> Message0 {
-        Message0 {
-            X: self.x_self.public(),
-            final_address: self.final_address_self.clone(),
-            fund_amount: self.fund_amount_self,
-            time_lock: self.time_lock,
-        }
-    }
-
-    pub async fn receive(
-        self,
-        Message0 {
-            X: X_other,
-            final_address: final_address_other,
-            fund_amount: fund_amount_other,
-            time_lock: time_lock_other,
-        }: Message0,
-        wallet: &impl BuildFundingPSBT,
-    ) -> anyhow::Result<Bob1> {
-        // NOTE: A real application would also verify that the amount
-        // provided by the other party is satisfactory, together with
-        // the time_lock
-        check_timelocks(self.time_lock, time_lock_other)?;
-
-        let fund_output = FundOutput::new(X_other.clone(), self.x_self.public());
-        let tid_self = wallet
-            .build_funding_psbt(fund_output.address(), self.fund_amount_self)
-            .await?;
-
-        let balance = Balance {
-            ours: self.fund_amount_self,
-            theirs: fund_amount_other,
-        };
-
-        Ok(Bob1 {
-            x_self: self.x_self,
-            X_other,
-            final_address_self: self.final_address_self,
-            final_address_other,
-            balance,
-            tid_self,
-            time_lock: self.time_lock,
-        })
-    }
-}
-
-#[derive(Debug)]
-pub struct Alice1 {
-    x_self: OwnershipKeyPair,
-    X_other: OwnershipPublicKey,
-    final_address_self: Address,
-    final_address_other: Address,
-    balance: Balance,
-    tid_self: PartiallySignedTransaction,
-    time_lock: u32,
-}
-
-impl Alice1 {
-    pub fn next_message(&self) -> Message1 {
-        Message1 {
-            tid: self.tid_self.clone(),
-        }
-    }
-
-    pub fn receive(self, Message1 { tid: tid_other }: Message1) -> anyhow::Result<Alice2> {
-        let TX_f = FundingTransaction::new(
-            (
-                self.x_self.public(),
-                self.tid_self.clone(),
-                self.balance.ours,
-            ),
-            (self.X_other.clone(), tid_other, self.balance.theirs),
-        )
-        .context("failed to build funding transaction")?;
-
-        let r = RevocationKeyPair::new_random();
-        let y = PublishingKeyPair::new_random();
-
-        Ok(Alice2 {
-            x_self: self.x_self,
-            X_other: self.X_other,
-            final_address_self: self.final_address_self,
-            final_address_other: self.final_address_other,
-            balance: self.balance,
-            time_lock: self.time_lock,
-            r_self: r,
-            y_self: y,
-            TX_f,
-        })
-    }
-}
-
-#[derive(Debug)]
-pub struct Bob1 {
-    x_self: OwnershipKeyPair,
-    X_other: OwnershipPublicKey,
-    final_address_self: Address,
-    final_address_other: Address,
-    balance: Balance,
-    tid_self: PartiallySignedTransaction,
-    time_lock: u32,
-}
-
-impl Bob1 {
-    pub fn next_message(&self) -> Message1 {
-        Message1 {
-            tid: self.tid_self.clone(),
-        }
-    }
-
-    pub fn receive(self, Message1 { tid: tid_other }: Message1) -> anyhow::Result<Bob2> {
-        let TX_f = FundingTransaction::new(
-            (self.X_other.clone(), tid_other, self.balance.theirs),
-            (
-                self.x_self.public(),
-                self.tid_self.clone(),
-                self.balance.ours,
-            ),
-        )
-        .context("failed to build funding transaction")?;
-
-        let r = RevocationKeyPair::new_random();
-        let y = PublishingKeyPair::new_random();
-
-        Ok(Bob2 {
-            x_self: self.x_self,
-            X_other: self.X_other,
-            final_address_self: self.final_address_self,
-            final_address_other: self.final_address_other,
-            balance: self.balance,
-            time_lock: self.time_lock,
-            r_self: r,
-            y_self: y,
-            TX_f,
         })
     }
 }
@@ -310,77 +153,56 @@ fn check_timelocks(time_lock_self: u32, time_lock_other: u32) -> Result<(), Inco
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct Alice2 {
+#[derive(Debug)]
+pub struct State1 {
     x_self: OwnershipKeyPair,
     X_other: OwnershipPublicKey,
     final_address_self: Address,
     final_address_other: Address,
     balance: Balance,
+    tid_self: PartiallySignedTransaction,
     time_lock: u32,
-    r_self: RevocationKeyPair,
-    y_self: PublishingKeyPair,
-    TX_f: FundingTransaction,
 }
 
-impl Alice2 {
-    pub fn next_message(&self) -> Message2 {
-        Message2 {
-            R: self.r_self.public(),
-            Y: self.y_self.public(),
+impl State1 {
+    pub fn next_message(&self) -> Message1 {
+        Message1 {
+            tid: self.tid_self.clone(),
         }
     }
 
-    pub fn receive(
-        self,
-        Message2 {
-            R: R_other,
-            Y: Y_other,
-        }: Message2,
-    ) -> anyhow::Result<Party3> {
-        let TX_c = CommitTransaction::new(
-            &self.TX_f,
+    pub fn receive(self, Message1 { tid: tid_other }: Message1) -> anyhow::Result<State2> {
+        let TX_f = FundingTransaction::new(
             (
                 self.x_self.public(),
-                self.r_self.public(),
-                self.y_self.public(),
+                self.tid_self.clone(),
+                self.balance.ours,
             ),
-            (self.X_other.clone(), R_other.clone(), Y_other.clone()),
-            self.time_lock,
-        )?;
-        let encsig_TX_c_self = TX_c.encsign_once(self.x_self.clone(), Y_other.clone());
+            (self.X_other.clone(), tid_other, self.balance.theirs),
+        )
+        .context("failed to build funding transaction")?;
 
-        let half_amount = TX_c.value() / 2;
-        let TX_s = SplitTransaction::new(
-            &TX_c,
-            half_amount,
-            self.final_address_self.clone(),
-            half_amount,
-            self.final_address_other.clone(),
-        );
-        let sig_TX_s_self = TX_s.sign_once(self.x_self.clone());
+        dbg!(&TX_f);
 
-        Ok(Party3 {
+        let r = RevocationKeyPair::new_random();
+        let y = PublishingKeyPair::new_random();
+
+        Ok(State2 {
             x_self: self.x_self,
             X_other: self.X_other,
             final_address_self: self.final_address_self,
             final_address_other: self.final_address_other,
             balance: self.balance,
-            r_self: self.r_self,
-            R_other,
-            y_self: self.y_self,
-            Y_other,
-            TX_f: self.TX_f,
-            TX_c,
-            TX_s,
-            encsig_TX_c_self,
-            sig_TX_s_self,
+            time_lock: self.time_lock,
+            r_self: r,
+            y_self: y,
+            TX_f,
         })
     }
 }
 
-#[derive(Debug)]
-pub struct Bob2 {
+#[derive(Clone, Debug)]
+pub struct State2 {
     x_self: OwnershipKeyPair,
     X_other: OwnershipPublicKey,
     final_address_self: Address,
@@ -392,7 +214,7 @@ pub struct Bob2 {
     TX_f: FundingTransaction,
 }
 
-impl Bob2 {
+impl State2 {
     pub fn next_message(&self) -> Message2 {
         Message2 {
             R: self.r_self.public(),
@@ -409,26 +231,27 @@ impl Bob2 {
     ) -> anyhow::Result<Party3> {
         let TX_c = CommitTransaction::new(
             &self.TX_f,
-            (self.X_other.clone(), R_other.clone(), Y_other.clone()),
-            (
-                self.x_self.public(),
-                self.r_self.public(),
-                self.y_self.public(),
-            ),
+            &[
+                (
+                    self.x_self.public(),
+                    self.r_self.public(),
+                    self.y_self.public(),
+                ),
+                (self.X_other.clone(), R_other.clone(), Y_other.clone()),
+            ],
             self.time_lock,
         )?;
-        let encsig_TX_c_self = TX_c.encsign_once(self.x_self.clone(), Y_other.clone());
+        let encsig_TX_c_self = dbg!(&TX_c).encsign_once(self.x_self.clone(), Y_other.clone());
 
         let half_amount = TX_c.value() / 2;
         let TX_s = SplitTransaction::new(
             &TX_c,
             half_amount,
-            self.final_address_other.clone(),
-            half_amount,
             self.final_address_self.clone(),
+            half_amount,
+            self.final_address_other.clone(),
         );
-
-        let sig_TX_s_self = TX_s.sign_once(self.x_self.clone());
+        let sig_TX_s_self = dbg!(&TX_s).sign_once(self.x_self.clone());
 
         Ok(Party3 {
             x_self: self.x_self,

--- a/thor/src/signature.rs
+++ b/thor/src/signature.rs
@@ -1,7 +1,4 @@
-use crate::{
-    keys::{OwnershipPublicKey, PublishingPublicKey, PublishingSecretKey},
-    transaction::CommitTransaction,
-};
+use crate::keys::{OwnershipPublicKey, PublishingPublicKey, PublishingSecretKey};
 use bitcoin::hashes::Hash;
 use ecdsa_fun::{
     adaptor::{Adaptor, EncryptedSignature},
@@ -18,14 +15,14 @@ pub struct InvalidSignature;
 
 pub fn verify_sig(
     verification_key: OwnershipPublicKey,
-    transaction_sig_hash: &SigHash,
+    transaction_sighash: &SigHash,
     signature: &Signature,
 ) -> Result<(), InvalidSignature> {
     let ecdsa = ECDSA::verify_only();
 
     if ecdsa.verify(
         &verification_key.into(),
-        &transaction_sig_hash.into_inner(),
+        &transaction_sighash.into_inner(),
         &signature,
     ) {
         Ok(())
@@ -41,7 +38,7 @@ pub struct InvalidEncryptedSignature;
 pub fn verify_encsig(
     verification_key: OwnershipPublicKey,
     encryption_key: PublishingPublicKey,
-    TX_c: &CommitTransaction,
+    transaction_sighash: &SigHash,
     encsig: &EncryptedSignature,
 ) -> Result<(), InvalidEncryptedSignature> {
     let adaptor = Adaptor::<Sha256, Deterministic<Sha256>>::default();
@@ -49,7 +46,7 @@ pub fn verify_encsig(
     if adaptor.verify_encrypted_signature(
         &verification_key.into(),
         &encryption_key.into(),
-        &TX_c.digest().into_inner(),
+        &transaction_sighash.into_inner(),
         &encsig,
     ) {
         Ok(())

--- a/thor/tests/e2e.rs
+++ b/thor/tests/e2e.rs
@@ -19,9 +19,8 @@ async fn e2e_channel_creation() {
     let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount).await.unwrap();
     let (mut alice_transport, mut bob_transport) = make_transports();
 
-    let alice_create =
-        Channel::create_alice(&mut alice_transport, &alice_wallet, fund_amount, time_lock);
-    let bob_create = Channel::create_bob(&mut bob_transport, &bob_wallet, fund_amount, time_lock);
+    let alice_create = Channel::create(&mut alice_transport, &alice_wallet, fund_amount, time_lock);
+    let bob_create = Channel::create(&mut bob_transport, &bob_wallet, fund_amount, time_lock);
 
     let (_alice_channel, _bob_channel) = futures::future::try_join(alice_create, bob_create)
         .await
@@ -40,9 +39,8 @@ async fn e2e_channel_update() {
     let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount).await.unwrap();
     let (mut alice_transport, mut bob_transport) = make_transports();
 
-    let alice_create =
-        Channel::create_alice(&mut alice_transport, &alice_wallet, fund_amount, time_lock);
-    let bob_create = Channel::create_bob(&mut bob_transport, &bob_wallet, fund_amount, time_lock);
+    let alice_create = Channel::create(&mut alice_transport, &alice_wallet, fund_amount, time_lock);
+    let bob_create = Channel::create(&mut bob_transport, &bob_wallet, fund_amount, time_lock);
 
     let (mut alice_channel, mut bob_channel) = futures::future::try_join(alice_create, bob_create)
         .await
@@ -53,7 +51,7 @@ async fn e2e_channel_update() {
     let alice_balance = fund_amount - payment;
     let bob_balance = fund_amount + payment;
 
-    let alice_update = alice_channel.update_alice(
+    let alice_update = alice_channel.update(
         &mut alice_transport,
         Balance {
             ours: alice_balance,
@@ -61,7 +59,7 @@ async fn e2e_channel_update() {
         },
         time_lock,
     );
-    let bob_update = bob_channel.update_bob(
+    let bob_update = bob_channel.update(
         &mut bob_transport,
         Balance {
             ours: bob_balance,
@@ -95,9 +93,8 @@ async fn e2e_punish_publication_of_revoked_commit_transaction() {
     let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount).await.unwrap();
     let (mut alice_transport, mut bob_transport) = make_transports();
 
-    let alice_create =
-        Channel::create_alice(&mut alice_transport, &alice_wallet, fund_amount, time_lock);
-    let bob_create = Channel::create_bob(&mut bob_transport, &bob_wallet, fund_amount, time_lock);
+    let alice_create = Channel::create(&mut alice_transport, &alice_wallet, fund_amount, time_lock);
+    let bob_create = Channel::create(&mut bob_transport, &bob_wallet, fund_amount, time_lock);
 
     let (mut alice_channel, mut bob_channel) = futures::future::try_join(alice_create, bob_create)
         .await
@@ -111,7 +108,7 @@ async fn e2e_punish_publication_of_revoked_commit_transaction() {
     let alice_balance = fund_amount - payment;
     let bob_balance = fund_amount + payment;
 
-    let alice_update = alice_channel.update_alice(
+    let alice_update = alice_channel.update(
         &mut alice_transport,
         Balance {
             ours: alice_balance,
@@ -119,7 +116,7 @@ async fn e2e_punish_publication_of_revoked_commit_transaction() {
         },
         time_lock,
     );
-    let bob_update = bob_channel.update_bob(
+    let bob_update = bob_channel.update(
         &mut bob_transport,
         Balance {
             ours: bob_balance,
@@ -174,9 +171,8 @@ async fn e2e_channel_collaborative_close() {
     let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount).await.unwrap();
     let (mut alice_transport, mut bob_transport) = make_transports();
 
-    let alice_create =
-        Channel::create_alice(&mut alice_transport, &alice_wallet, fund_amount, time_lock);
-    let bob_create = Channel::create_bob(&mut bob_transport, &bob_wallet, fund_amount, time_lock);
+    let alice_create = Channel::create(&mut alice_transport, &alice_wallet, fund_amount, time_lock);
+    let bob_create = Channel::create(&mut bob_transport, &bob_wallet, fund_amount, time_lock);
 
     let (mut alice_channel, mut bob_channel) = futures::future::try_join(alice_create, bob_create)
         .await
@@ -225,9 +221,8 @@ async fn e2e_force_close_channel() {
     let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount).await.unwrap();
     let (mut alice_transport, mut bob_transport) = make_transports();
 
-    let alice_create =
-        Channel::create_alice(&mut alice_transport, &alice_wallet, fund_amount, time_lock);
-    let bob_create = Channel::create_bob(&mut bob_transport, &bob_wallet, fund_amount, time_lock);
+    let alice_create = Channel::create(&mut alice_transport, &alice_wallet, fund_amount, time_lock);
+    let bob_create = Channel::create(&mut bob_transport, &bob_wallet, fund_amount, time_lock);
 
     let (mut alice_channel, _bob_channel) = futures::future::try_join(alice_create, bob_create)
         .await

--- a/thor/tests/harness/wallet.rs
+++ b/thor/tests/harness/wallet.rs
@@ -1,10 +1,7 @@
 use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount};
 use bitcoin_harness::{bitcoind_rpc::PsbtBase64, Bitcoind};
 use reqwest::Url;
-use thor::{
-    protocols::create::{BuildFundingPSBT, SignFundingPSBT},
-    BroadcastSignedTransaction, NewAddress,
-};
+use thor::{BroadcastSignedTransaction, BuildFundingPSBT, NewAddress, SignFundingPSBT};
 
 pub struct Wallet(pub bitcoin_harness::Wallet);
 


### PR DESCRIPTION
This is achieved by:

- Sorting inputs in transactions by ascending lexicographical order of `previous_output` (whose `OutPoint` type defines its own order via the `Ord` trait).
- Sorting outputs in transactions by ascending lexicographical order of `script_pubkey` (whose `Script` type defines its own order via the `Ord` trait).
- Sorting public keys in Miniscript descriptors by ascending lexicographical order of bytes.