### PR TITLE
Remove anyhow

### DIFF
--- a/thor/Cargo.toml
+++ b/thor/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["CoBloX Team <team@coblox.tech>"]
 edition = "2018"
 
 [dependencies]
-anyhow = "1"
 arrayvec = "0.5"
 async-trait = "0.1"
 base64 = "0.12"
@@ -22,6 +21,7 @@ sha2 = "0.9"
 thiserror = "1"
 
 [dev-dependencies]
+anyhow = "1"
 bitcoin-harness = { git = "https://github.com/coblox/bitcoin-harness-rs.git", rev = "a695ddc435f5522d7bc35847caf09df85257cc6b" }
 reqwest = { version = "0.10", default-features = false }
 serde_json = "1"

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -89,93 +89,39 @@ impl Channel {
         let state0 = create::State0::new(fund_amount, time_lock, final_address);
 
         let msg0_self = state0.next_message();
-        transport
-            .send_message(Message::Create0(msg0_self))
-            .await
-            .map_err(Error::transport)?;
+        transport.send_message(Message::Create0(msg0_self)).await?;
 
-        let msg0_other = map_msg_err(
-            transport
-                .receive_message()
-                .await
-                .map_err(Error::transport)?
-                .into_create0(),
-        )?;
+        let msg0_other = map_msg_err(transport.receive_message().await?.into_create0())?;
         let state1 = state0.receive(msg0_other, wallet).await?;
 
         let msg1_self = state1.next_message();
-        transport
-            .send_message(Message::Create1(msg1_self))
-            .await
-            .map_err(Error::transport)?;
+        transport.send_message(Message::Create1(msg1_self)).await?;
 
-        let msg1_other = map_msg_err(
-            transport
-                .receive_message()
-                .await
-                .map_err(Error::transport)?
-                .into_create1(),
-        )?;
+        let msg1_other = map_msg_err(transport.receive_message().await?.into_create1())?;
         let state2 = state1.receive(msg1_other)?;
 
         let msg2_self = state2.next_message();
-        transport
-            .send_message(Message::Create2(msg2_self))
-            .await
-            .map_err(Error::transport)?;
+        transport.send_message(Message::Create2(msg2_self)).await?;
 
-        let msg2_other = map_msg_err(
-            transport
-                .receive_message()
-                .await
-                .map_err(Error::transport)?
-                .into_create2(),
-        )?;
+        let msg2_other = map_msg_err(transport.receive_message().await?.into_create2())?;
         let state3 = state2.receive(msg2_other)?;
 
         let msg3_self = state3.next_message();
-        transport
-            .send_message(Message::Create3(msg3_self))
-            .await
-            .map_err(Error::transport)?;
+        transport.send_message(Message::Create3(msg3_self)).await?;
 
-        let msg3_other = map_msg_err(
-            transport
-                .receive_message()
-                .await
-                .map_err(Error::transport)?
-                .into_create3(),
-        )?;
+        let msg3_other = map_msg_err(transport.receive_message().await?.into_create3())?;
         let state_4 = state3.receive(msg3_other)?;
 
         let msg4_self = state_4.next_message();
-        transport
-            .send_message(Message::Create4(msg4_self))
-            .await
-            .map_err(Error::transport)?;
+        transport.send_message(Message::Create4(msg4_self)).await?;
 
-        let msg4_other = map_msg_err(
-            transport
-                .receive_message()
-                .await
-                .map_err(Error::transport)?
-                .into_create4(),
-        )?;
+        let msg4_other = map_msg_err(transport.receive_message().await?.into_create4())?;
         let state5 = state_4.receive(msg4_other)?;
 
         let msg5_self = state5.next_message(wallet).await?;
-        transport
-            .send_message(Message::Create5(msg5_self))
-            .await
-            .map_err(Error::transport)?;
+        transport.send_message(Message::Create5(msg5_self)).await?;
 
-        let msg5_other = map_msg_err(
-            transport
-                .receive_message()
-                .await
-                .map_err(Error::transport)?
-                .into_create5(),
-        )?;
+        let msg5_other = map_msg_err(transport.receive_message().await?.into_create5())?;
 
         let (channel, transaction) = state5.receive(msg5_other, wallet).await?;
 
@@ -208,63 +154,27 @@ impl Channel {
         let state0 = update::State0::new(self.clone(), new_balance, time_lock);
 
         let msg0_self = state0.compose();
-        transport
-            .send_message(Message::Update0(msg0_self))
-            .await
-            .map_err(Error::transport)?;
+        transport.send_message(Message::Update0(msg0_self)).await?;
 
-        let msg0_other = map_msg_err(
-            transport
-                .receive_message()
-                .await
-                .map_err(Error::transport)?
-                .into_update0(),
-        )?;
+        let msg0_other = map_msg_err(transport.receive_message().await?.into_update0())?;
         let state1 = state0.interpret(msg0_other)?;
 
         let msg1_self = state1.compose();
-        transport
-            .send_message(Message::Update1(msg1_self))
-            .await
-            .map_err(Error::transport)?;
+        transport.send_message(Message::Update1(msg1_self)).await?;
 
-        let msg1_other = map_msg_err(
-            transport
-                .receive_message()
-                .await
-                .map_err(Error::transport)?
-                .into_update1(),
-        )?;
+        let msg1_other = map_msg_err(transport.receive_message().await?.into_update1())?;
         let state2 = state1.interpret(msg1_other)?;
 
         let msg2_self = state2.compose();
-        transport
-            .send_message(Message::Update2(msg2_self))
-            .await
-            .map_err(Error::transport)?;
+        transport.send_message(Message::Update2(msg2_self)).await?;
 
-        let msg2_other = map_msg_err(
-            transport
-                .receive_message()
-                .await
-                .map_err(Error::transport)?
-                .into_update2(),
-        )?;
+        let msg2_other = map_msg_err(transport.receive_message().await?.into_update2())?;
         let state3 = state2.interpret(msg2_other)?;
 
         let msg3_self = state3.compose();
-        transport
-            .send_message(Message::Update3(msg3_self))
-            .await
-            .map_err(Error::transport)?;
+        transport.send_message(Message::Update3(msg3_self)).await?;
 
-        let msg3_other = map_msg_err(
-            transport
-                .receive_message()
-                .await
-                .map_err(Error::transport)?
-                .into_update3(),
-        )?;
+        let msg3_other = map_msg_err(transport.receive_message().await?.into_update3())?;
         let updated_channel = state3.interpret(msg3_other)?;
 
         *self = updated_channel;
@@ -288,18 +198,9 @@ impl Channel {
         let state0 = close::State0::new(&self);
 
         let msg0_self = state0.compose()?;
-        transport
-            .send_message(Message::Close0(msg0_self))
-            .await
-            .map_err(Error::transport)?;
+        transport.send_message(Message::Close0(msg0_self)).await?;
 
-        let msg0_other = map_msg_err(
-            transport
-                .receive_message()
-                .await
-                .map_err(Error::transport)?
-                .into_close0(),
-        )?;
+        let msg0_other = map_msg_err(transport.receive_message().await?.into_close0())?;
         let close_transaction = state0.interpret(msg0_other)?;
 
         wallet
@@ -501,11 +402,8 @@ impl Error {
         }))
     }
 
-    pub fn transport<E>(error: E) -> Self
-    where
-        E: std::fmt::Display,
-    {
-        Self::Transport(error.to_string())
+    pub fn custom(error: String) -> Self {
+        Self::Custom(error)
     }
 
     pub fn wallet<E>(error: E) -> Self
@@ -540,8 +438,6 @@ pub enum Error {
     NotOldCommitTransaction,
     #[error("{0}")]
     UnexpectedMessage(Box<UnexpectedMessage>),
-    #[error("Transport: {0}")]
-    Transport(String),
     #[error("Wallet: {0}")]
     Wallet(String),
     #[error("{0}")]

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -414,3 +414,25 @@ impl UnexpecteMessage {
 fn map_err<T>(res: Result<T, Message>) -> Result<T, UnexpecteMessage> {
     res.map_err(UnexpecteMessage::new::<T>)
 }
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Transaction: ")]
+    Transaction(#[from] crate::transaction::Error),
+    #[error("Keys: ")]
+    Keys(#[from] crate::keys::Error),
+    #[error("Failed to verify close transaction signature sent by counterparty: ")]
+    CloseTransactionSignature(crate::transaction::Error),
+    #[error("Timelocks are not equal")]
+    IncompatibleTimeLocks,
+    #[error("Failed to build funding transaction: ")]
+    BuildFundTransaction(crate::transaction::Error),
+    #[error("Failed to verify sig_TX_s sent by counterparty: ")]
+    VerifyReceivedSigTXs(crate::transaction::Error),
+    #[error("Failed to verify encsig_TX_c sent by counterparty: ")]
+    VerifyReceivedEncSigTXc(crate::transaction::Error),
+    #[error("Transaction cannot be punished")]
+    NotOldCommitTransaction,
+    #[error("{0}")]
+    Custom(String),
+}

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -20,10 +20,14 @@ pub(crate) mod serde;
 mod keys;
 mod protocols;
 mod signature;
+mod traits;
 mod transaction;
 
 pub use ::bitcoin;
-pub use protocols::create::{BuildFundingPSBT, SignFundingPSBT};
+pub use traits::{
+    BroadcastSignedTransaction, BuildFundingPSBT, NewAddress, ReceiveMessage, SendMessage,
+    SignFundingPSBT,
+};
 
 use crate::{
     keys::{
@@ -54,26 +58,6 @@ pub struct Channel {
     TX_f_body: FundingTransaction,
     current_state: ChannelState,
     revoked_states: Vec<RevokedState>,
-}
-
-#[async_trait::async_trait]
-pub trait NewAddress {
-    async fn new_address(&self) -> anyhow::Result<Address>;
-}
-
-#[async_trait::async_trait]
-pub trait BroadcastSignedTransaction {
-    async fn broadcast_signed_transaction(&self, transaction: Transaction) -> anyhow::Result<()>;
-}
-
-#[async_trait::async_trait]
-pub trait SendMessage {
-    async fn send_message(&mut self, message: Message) -> anyhow::Result<()>;
-}
-
-#[async_trait::async_trait]
-pub trait ReceiveMessage {
-    async fn receive_message(&mut self) -> anyhow::Result<Message>;
 }
 
 impl Channel {

--- a/thor/src/protocols.rs
+++ b/thor/src/protocols.rs
@@ -2,3 +2,5 @@ pub mod close;
 pub mod create;
 pub mod punish;
 pub mod update;
+
+pub type Result<T> = std::result::Result<T, crate::Error>;

--- a/thor/src/protocols.rs
+++ b/thor/src/protocols.rs
@@ -2,5 +2,3 @@ pub mod close;
 pub mod create;
 pub mod punish;
 pub mod update;
-
-pub type Result<T> = std::result::Result<T, crate::Error>;

--- a/thor/src/protocols/close.rs
+++ b/thor/src/protocols/close.rs
@@ -1,8 +1,7 @@
 use crate::{
     keys::{OwnershipKeyPair, OwnershipPublicKey},
-    protocols::Result,
     transaction::{CloseTransaction, FundingTransaction},
-    Balance, Channel, Error,
+    Balance, Channel, Error, Result,
 };
 use bitcoin::{Address, Transaction};
 use ecdsa_fun::Signature;

--- a/thor/src/protocols/create.rs
+++ b/thor/src/protocols/create.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     protocols::Result,
     transaction::{CommitTransaction, FundOutput, SplitTransaction},
-    Balance, Channel, ChannelState, Error,
+    Balance, BuildFundingPSBT, Channel, ChannelState, Error, SignFundingPSBT,
 };
 use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount, Transaction};
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
@@ -70,17 +70,6 @@ pub struct State0 {
     final_address_self: Address,
     fund_amount_self: Amount,
     time_lock: u32,
-}
-
-#[async_trait::async_trait]
-pub trait BuildFundingPSBT {
-    type Error: std::fmt::Display;
-
-    async fn build_funding_psbt(
-        &self,
-        output_address: Address,
-        output_amount: Amount,
-    ) -> std::result::Result<PartiallySignedTransaction, Self::Error>;
 }
 
 impl State0 {
@@ -400,17 +389,6 @@ pub struct Party5 {
     signed_TX_s: SplitTransaction,
     encsig_TX_c_self: EncryptedSignature,
     encsig_TX_c_other: EncryptedSignature,
-}
-
-/// Sign one of the inputs of the `FundingTransaction`.
-#[async_trait::async_trait]
-pub trait SignFundingPSBT {
-    type Error: std::fmt::Display;
-
-    async fn sign_funding_psbt(
-        &self,
-        psbt: PartiallySignedTransaction,
-    ) -> std::result::Result<PartiallySignedTransaction, Self::Error>;
 }
 
 impl Party5 {

--- a/thor/src/protocols/create.rs
+++ b/thor/src/protocols/create.rs
@@ -3,9 +3,8 @@ use crate::{
         OwnershipKeyPair, OwnershipPublicKey, PublishingKeyPair, PublishingPublicKey,
         RevocationKeyPair, RevocationPublicKey,
     },
-    protocols::Result,
     transaction::{CommitTransaction, FundOutput, SplitTransaction},
-    Balance, BuildFundingPSBT, Channel, ChannelState, Error, SignFundingPSBT,
+    Balance, BuildFundingPSBT, Channel, ChannelState, Error, Result, SignFundingPSBT,
 };
 use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount, Transaction};
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};

--- a/thor/src/protocols/punish.rs
+++ b/thor/src/protocols/punish.rs
@@ -1,16 +1,15 @@
-use crate::{keys::OwnershipKeyPair, transaction::PunishTransaction, ChannelState, RevokedState};
+use crate::{
+    keys::OwnershipKeyPair, protocols::Result, transaction::PunishTransaction, ChannelState, Error,
+    RevokedState,
+};
 use bitcoin::{Address, Transaction};
-
-#[derive(Copy, Clone, Debug, thiserror::Error)]
-#[error("transaction cannot be punished")]
-pub struct NotOldCommitTransaction;
 
 pub fn punish(
     x_self: &OwnershipKeyPair,
     revoked_states: &[RevokedState],
     final_address: Address,
     old_commit_transaction: Transaction,
-) -> anyhow::Result<PunishTransaction> {
+) -> Result<PunishTransaction> {
     let RevokedState {
         channel_state:
             ChannelState {
@@ -23,7 +22,7 @@ pub fn punish(
     } = revoked_states
         .iter()
         .find(|state| state.channel_state.TX_c.txid() == old_commit_transaction.txid())
-        .ok_or_else(|| NotOldCommitTransaction)?;
+        .ok_or_else(|| Error::NotOldCommitTransaction)?;
 
     let TX_p = PunishTransaction::new(
         x_self,

--- a/thor/src/protocols/punish.rs
+++ b/thor/src/protocols/punish.rs
@@ -1,5 +1,5 @@
 use crate::{
-    keys::OwnershipKeyPair, protocols::Result, transaction::PunishTransaction, ChannelState, Error,
+    keys::OwnershipKeyPair, transaction::PunishTransaction, ChannelState, Error, Result,
     RevokedState,
 };
 use bitcoin::{Address, Transaction};

--- a/thor/src/protocols/update.rs
+++ b/thor/src/protocols/update.rs
@@ -3,9 +3,8 @@ use crate::{
         OwnershipKeyPair, OwnershipPublicKey, PublishingKeyPair, PublishingPublicKey,
         RevocationKeyPair, RevocationPublicKey, RevocationSecretKey,
     },
-    protocols::Result,
     transaction::{CommitTransaction, FundingTransaction, SplitTransaction},
-    Balance, Channel, ChannelState, Error, RevokedState,
+    Balance, Channel, ChannelState, Error, Result, RevokedState,
 };
 use bitcoin::Address;
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};

--- a/thor/src/signature.rs
+++ b/thor/src/signature.rs
@@ -9,7 +9,7 @@ use ecdsa_fun::{
 use bitcoin::SigHash;
 use sha2::Sha256;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Copy, Clone, Debug, thiserror::Error)]
 #[error("signature is invalid")]
 pub struct InvalidSignature;
 
@@ -31,7 +31,7 @@ pub fn verify_sig(
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Copy, Clone, Debug, thiserror::Error)]
 #[error("encrypted signature is invalid")]
 pub struct InvalidEncryptedSignature;
 

--- a/thor/src/traits.rs
+++ b/thor/src/traits.rs
@@ -3,12 +3,19 @@ use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount, Transacti
 
 #[async_trait::async_trait]
 pub trait NewAddress {
-    async fn new_address(&self) -> anyhow::Result<Address>;
+    type Error: std::fmt::Display;
+
+    async fn new_address(&self) -> Result<Address, Self::Error>;
 }
 
 #[async_trait::async_trait]
 pub trait BroadcastSignedTransaction {
-    async fn broadcast_signed_transaction(&self, transaction: Transaction) -> anyhow::Result<()>;
+    type Error: std::fmt::Display;
+
+    async fn broadcast_signed_transaction(
+        &self,
+        transaction: Transaction,
+    ) -> Result<(), Self::Error>;
 }
 
 /// Sign one of the inputs of the `FundingTransaction`.
@@ -35,10 +42,14 @@ pub trait BuildFundingPSBT {
 
 #[async_trait::async_trait]
 pub trait SendMessage {
-    async fn send_message(&mut self, message: Message) -> anyhow::Result<()>;
+    type Error: std::fmt::Display;
+
+    async fn send_message(&mut self, message: Message) -> Result<(), Self::Error>;
 }
 
 #[async_trait::async_trait]
 pub trait ReceiveMessage {
-    async fn receive_message(&mut self) -> anyhow::Result<Message>;
+    type Error: std::fmt::Display;
+
+    async fn receive_message(&mut self) -> Result<Message, Self::Error>;
 }

--- a/thor/src/traits.rs
+++ b/thor/src/traits.rs
@@ -1,55 +1,40 @@
-use crate::Message;
+use crate::{Message, Result};
 use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount, Transaction};
 
 #[async_trait::async_trait]
 pub trait NewAddress {
-    type Error: std::fmt::Display;
-
-    async fn new_address(&self) -> Result<Address, Self::Error>;
+    async fn new_address(&self) -> Result<Address>;
 }
 
 #[async_trait::async_trait]
 pub trait BroadcastSignedTransaction {
-    type Error: std::fmt::Display;
-
-    async fn broadcast_signed_transaction(
-        &self,
-        transaction: Transaction,
-    ) -> Result<(), Self::Error>;
+    async fn broadcast_signed_transaction(&self, transaction: Transaction) -> Result<()>;
 }
 
 /// Sign one of the inputs of the `FundingTransaction`.
 #[async_trait::async_trait]
 pub trait SignFundingPSBT {
-    type Error: std::fmt::Display;
-
     async fn sign_funding_psbt(
         &self,
         psbt: PartiallySignedTransaction,
-    ) -> Result<PartiallySignedTransaction, Self::Error>;
+    ) -> Result<PartiallySignedTransaction>;
 }
 
 #[async_trait::async_trait]
 pub trait BuildFundingPSBT {
-    type Error: std::fmt::Display;
-
     async fn build_funding_psbt(
         &self,
         output_address: Address,
         output_amount: Amount,
-    ) -> Result<PartiallySignedTransaction, Self::Error>;
+    ) -> Result<PartiallySignedTransaction>;
 }
 
 #[async_trait::async_trait]
 pub trait SendMessage {
-    type Error: std::fmt::Display;
-
-    async fn send_message(&mut self, message: Message) -> Result<(), Self::Error>;
+    async fn send_message(&mut self, message: Message) -> Result<()>;
 }
 
 #[async_trait::async_trait]
 pub trait ReceiveMessage {
-    type Error: std::fmt::Display;
-
-    async fn receive_message(&mut self) -> Result<Message, Self::Error>;
+    async fn receive_message(&mut self) -> Result<Message>;
 }

--- a/thor/src/traits.rs
+++ b/thor/src/traits.rs
@@ -1,0 +1,44 @@
+use crate::Message;
+use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount, Transaction};
+
+#[async_trait::async_trait]
+pub trait NewAddress {
+    async fn new_address(&self) -> anyhow::Result<Address>;
+}
+
+#[async_trait::async_trait]
+pub trait BroadcastSignedTransaction {
+    async fn broadcast_signed_transaction(&self, transaction: Transaction) -> anyhow::Result<()>;
+}
+
+/// Sign one of the inputs of the `FundingTransaction`.
+#[async_trait::async_trait]
+pub trait SignFundingPSBT {
+    type Error: std::fmt::Display;
+
+    async fn sign_funding_psbt(
+        &self,
+        psbt: PartiallySignedTransaction,
+    ) -> Result<PartiallySignedTransaction, Self::Error>;
+}
+
+#[async_trait::async_trait]
+pub trait BuildFundingPSBT {
+    type Error: std::fmt::Display;
+
+    async fn build_funding_psbt(
+        &self,
+        output_address: Address,
+        output_amount: Amount,
+    ) -> Result<PartiallySignedTransaction, Self::Error>;
+}
+
+#[async_trait::async_trait]
+pub trait SendMessage {
+    async fn send_message(&mut self, message: Message) -> anyhow::Result<()>;
+}
+
+#[async_trait::async_trait]
+pub trait ReceiveMessage {
+    async fn receive_message(&mut self) -> anyhow::Result<Message>;
+}

--- a/thor/tests/harness/transport.rs
+++ b/thor/tests/harness/transport.rs
@@ -34,6 +34,8 @@ pub fn make_transports() -> (Transport, Transport) {
 
 #[async_trait::async_trait]
 impl SendMessage for Transport {
+    type Error = anyhow::Error;
+
     async fn send_message(&mut self, message: Message) -> anyhow::Result<()> {
         let str = serde_json::to_string(&message).context("failed to encode message")?;
         self.sender
@@ -45,6 +47,8 @@ impl SendMessage for Transport {
 
 #[async_trait::async_trait]
 impl ReceiveMessage for Transport {
+    type Error = anyhow::Error;
+
     async fn receive_message(&mut self) -> anyhow::Result<Message> {
         let str = self
             .receiver

--- a/thor/tests/harness/wallet.rs
+++ b/thor/tests/harness/wallet.rs
@@ -38,6 +38,8 @@ pub async fn make_wallets(
 
 #[async_trait::async_trait]
 impl BuildFundingPSBT for Wallet {
+    type Error = anyhow::Error;
+
     async fn build_funding_psbt(
         &self,
         output_address: Address,
@@ -54,6 +56,8 @@ impl BuildFundingPSBT for Wallet {
 
 #[async_trait::async_trait]
 impl SignFundingPSBT for Wallet {
+    type Error = anyhow::Error;
+
     async fn sign_funding_psbt(
         &self,
         psbt: PartiallySignedTransaction,

--- a/thor/tests/harness/wallet.rs
+++ b/thor/tests/harness/wallet.rs
@@ -77,6 +77,8 @@ impl SignFundingPSBT for Wallet {
 
 #[async_trait::async_trait]
 impl BroadcastSignedTransaction for Wallet {
+    type Error = anyhow::Error;
+
     async fn broadcast_signed_transaction(
         &self,
         transaction: bitcoin::Transaction,
@@ -95,6 +97,8 @@ impl BroadcastSignedTransaction for Wallet {
 
 #[async_trait::async_trait]
 impl NewAddress for Wallet {
+    type Error = anyhow::Error;
+
     async fn new_address(&self) -> anyhow::Result<Address> {
         self.0.new_address().await.map_err(Into::into)
     }


### PR DESCRIPTION
The reasoning is that for a library, having a dedicated Error type makes it more easier to handle error in a programmatic manner.
It is easier to do the migration now than do it once we actually use the library and want to programatically handle some error cases.