### PR TITLE
Implement recycle protocol

### DIFF
--- a/thor/src/protocols.rs
+++ b/thor/src/protocols.rs
@@ -1,4 +1,5 @@
 pub mod close;
 pub mod create;
 pub mod punish;
+pub mod recycle;
 pub mod update;

--- a/thor/src/protocols/create.rs
+++ b/thor/src/protocols/create.rs
@@ -175,7 +175,7 @@ impl State1 {
             input_psbt: input_pstb_other,
         }: Message1,
     ) -> anyhow::Result<State2> {
-        let TX_f = FundingTransaction::new([self.input_psbt_self.clone(), input_pstb_other], [
+        let TX_f = FundingTransaction::new(vec![self.input_psbt_self.clone(), input_pstb_other], [
             (self.x_self.public(), self.balance.ours),
             (self.X_other.clone(), self.balance.theirs),
         ])

--- a/thor/src/protocols/create.rs
+++ b/thor/src/protocols/create.rs
@@ -175,13 +175,9 @@ impl State1 {
             input_psbt: input_pstb_other,
         }: Message1,
     ) -> anyhow::Result<State2> {
-        let TX_f = FundingTransaction::new([
-            (
-                self.x_self.public(),
-                self.input_psbt_self.clone(),
-                self.balance.ours,
-            ),
-            (self.X_other.clone(), input_pstb_other, self.balance.theirs),
+        let TX_f = FundingTransaction::new([self.input_psbt_self.clone(), input_pstb_other], [
+            (self.x_self.public(), self.balance.ours),
+            (self.X_other.clone(), self.balance.theirs),
         ])
         .context("failed to build funding transaction")?;
 

--- a/thor/src/protocols/recycle.rs
+++ b/thor/src/protocols/recycle.rs
@@ -1,0 +1,346 @@
+use crate::{
+    keys::{
+        OwnershipKeyPair, OwnershipPublicKey, PublishingKeyPair, PublishingPublicKey,
+        RevocationKeyPair, RevocationPublicKey,
+    },
+    transaction::{CommitTransaction, SplitTransaction},
+    Balance, Channel, ChannelState,
+};
+use anyhow::Context;
+use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount, Transaction};
+use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
+
+pub use crate::transaction::FundingTransaction;
+use miniscript::Descriptor;
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug)]
+pub struct Message0 {
+    R: RevocationPublicKey,
+    Y: PublishingPublicKey,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug)]
+pub struct Message1 {
+    sig_TX_s: Signature,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug)]
+pub struct Message2 {
+    encsig_TX_c: EncryptedSignature,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug)]
+pub struct Message3 {
+    sig_TX_f: Signature,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct State0 {
+    x_self: OwnershipKeyPair,
+    X_other: OwnershipPublicKey,
+    final_address_self: Address,
+    final_address_other: Address,
+    balance: Balance,
+    previous_TX_f_output_descriptor: Descriptor<bitcoin::PublicKey>,
+    TX_f: FundingTransaction,
+    sig_TX_f: Signature,
+    time_lock: u32,
+    r_self: RevocationKeyPair,
+    y_self: PublishingKeyPair,
+}
+
+impl State0 {
+    pub fn new(
+        time_lock: u32,
+        final_address_self: Address,
+        final_address_other: Address,
+        previous_balance: Balance,
+        previous_TX_f: FundingTransaction,
+        x_self: OwnershipKeyPair,
+        X_other: OwnershipPublicKey,
+    ) -> anyhow::Result<State0> {
+        let previous_funding_txin = previous_TX_f.as_txin();
+        let previous_funding_psbt = PartiallySignedTransaction::from_unsigned_tx(Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![previous_funding_txin],
+            output: vec![],
+        })
+        .expect("Only fails if script_sig or witness is empty which is not the case.");
+
+        let balance = Balance {
+            ours: previous_balance.ours - Amount::from_sat(crate::TX_FEE / 2),
+            theirs: previous_balance.theirs - Amount::from_sat(crate::TX_FEE / 2),
+        };
+
+        let TX_f = FundingTransaction::new(vec![previous_funding_psbt], [
+            (x_self.public(), balance.ours),
+            (X_other.clone(), balance.theirs),
+        ])?;
+
+        let sig_TX_f = TX_f.sign_once(x_self.clone(), &previous_TX_f);
+
+        let r = RevocationKeyPair::new_random();
+        let y = PublishingKeyPair::new_random();
+
+        Ok(State0 {
+            x_self,
+            TX_f,
+            X_other,
+            final_address_self,
+            final_address_other,
+            balance,
+            previous_TX_f_output_descriptor: previous_TX_f.fund_output_descriptor(),
+            sig_TX_f,
+            r_self: r,
+            y_self: y,
+            time_lock,
+        })
+    }
+
+    pub fn next_message(&self) -> Message0 {
+        Message0 {
+            R: self.r_self.public(),
+            Y: self.y_self.public(),
+        }
+    }
+
+    pub fn receive(
+        self,
+        Message0 {
+            R: R_other,
+            Y: Y_other,
+        }: Message0,
+    ) -> anyhow::Result<State1> {
+        let TX_c = CommitTransaction::new(
+            &self.TX_f,
+            [
+                (
+                    self.x_self.public(),
+                    self.r_self.public(),
+                    self.y_self.public(),
+                ),
+                (self.X_other.clone(), R_other.clone(), Y_other.clone()),
+            ],
+            self.time_lock,
+        )?;
+        let encsig_TX_c_self = TX_c.encsign_once(self.x_self.clone(), Y_other.clone());
+
+        let TX_s = SplitTransaction::new(&TX_c, [
+            (self.balance.ours, self.final_address_self.clone()),
+            (self.balance.theirs, self.final_address_other.clone()),
+        ])?;
+        let sig_TX_s_self = TX_s.sign_once(self.x_self.clone());
+
+        Ok(State1 {
+            x_self: self.x_self,
+            X_other: self.X_other,
+            final_address_self: self.final_address_self,
+            final_address_other: self.final_address_other,
+            balance: self.balance,
+            r_self: self.r_self,
+            R_other,
+            y_self: self.y_self,
+            Y_other,
+            previous_TX_f_output_descriptor: self.previous_TX_f_output_descriptor,
+            TX_f: self.TX_f,
+            sig_TX_f: self.sig_TX_f,
+            TX_c,
+            TX_s,
+            encsig_TX_c_self,
+            sig_TX_s_self,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct State1 {
+    x_self: OwnershipKeyPair,
+    X_other: OwnershipPublicKey,
+    final_address_self: Address,
+    final_address_other: Address,
+    balance: Balance,
+    r_self: RevocationKeyPair,
+    R_other: RevocationPublicKey,
+    y_self: PublishingKeyPair,
+    Y_other: PublishingPublicKey,
+    previous_TX_f_output_descriptor: Descriptor<bitcoin::PublicKey>,
+    TX_f: FundingTransaction,
+    sig_TX_f: Signature,
+    TX_c: CommitTransaction,
+    TX_s: SplitTransaction,
+    encsig_TX_c_self: EncryptedSignature,
+    sig_TX_s_self: Signature,
+}
+
+impl State1 {
+    pub fn next_message(&self) -> Message1 {
+        Message1 {
+            sig_TX_s: self.sig_TX_s_self.clone(),
+        }
+    }
+
+    pub fn receive(
+        mut self,
+        Message1 {
+            sig_TX_s: sig_TX_s_other,
+        }: Message1,
+    ) -> anyhow::Result<State2> {
+        self.TX_s
+            .verify_sig(self.X_other.clone(), &sig_TX_s_other)
+            .context("failed to verify sig_TX_s sent by counterparty")?;
+
+        self.TX_s.add_signatures(
+            (self.x_self.public(), self.sig_TX_s_self),
+            (self.X_other.clone(), sig_TX_s_other),
+        )?;
+
+        Ok(State2 {
+            x_self: self.x_self,
+            X_other: self.X_other,
+            final_address_self: self.final_address_self,
+            final_address_other: self.final_address_other,
+            balance: self.balance,
+            r_self: self.r_self,
+            R_other: self.R_other,
+            y_self: self.y_self,
+            Y_other: self.Y_other,
+            previous_TX_f_output_descriptor: self.previous_TX_f_output_descriptor,
+            TX_f: self.TX_f,
+            sig_TX_f: self.sig_TX_f,
+            TX_c: self.TX_c,
+            signed_TX_s: self.TX_s,
+            encsig_TX_c_self: self.encsig_TX_c_self,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct State2 {
+    x_self: OwnershipKeyPair,
+    X_other: OwnershipPublicKey,
+    final_address_self: Address,
+    final_address_other: Address,
+    balance: Balance,
+    r_self: RevocationKeyPair,
+    R_other: RevocationPublicKey,
+    y_self: PublishingKeyPair,
+    Y_other: PublishingPublicKey,
+    previous_TX_f_output_descriptor: Descriptor<bitcoin::PublicKey>,
+    TX_f: FundingTransaction,
+    sig_TX_f: Signature,
+    TX_c: CommitTransaction,
+    signed_TX_s: SplitTransaction,
+    encsig_TX_c_self: EncryptedSignature,
+}
+
+impl State2 {
+    pub fn next_message(&self) -> Message2 {
+        Message2 {
+            encsig_TX_c: self.encsig_TX_c_self.clone(),
+        }
+    }
+
+    pub fn receive(
+        self,
+        Message2 {
+            encsig_TX_c: encsig_TX_c_other,
+        }: Message2,
+    ) -> anyhow::Result<State3> {
+        self.TX_c
+            .verify_encsig(
+                self.X_other.clone(),
+                self.y_self.public(),
+                &encsig_TX_c_other,
+            )
+            .context("failed to verify encsig_TX_c sent by counterparty")?;
+
+        Ok(State3 {
+            x_self: self.x_self,
+            X_other: self.X_other,
+            final_address_self: self.final_address_self,
+            final_address_other: self.final_address_other,
+            balance: self.balance,
+            r_self: self.r_self,
+            R_other: self.R_other,
+            y_self: self.y_self,
+            Y_other: self.Y_other,
+            previous_TX_f_output_descriptor: self.previous_TX_f_output_descriptor,
+            TX_f: self.TX_f,
+            sig_TX_f: self.sig_TX_f,
+            TX_c: self.TX_c,
+            signed_TX_s: self.signed_TX_s,
+            encsig_TX_c_self: self.encsig_TX_c_self,
+            encsig_TX_c_other,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct State3 {
+    x_self: OwnershipKeyPair,
+    X_other: OwnershipPublicKey,
+    final_address_self: Address,
+    final_address_other: Address,
+    balance: Balance,
+    r_self: RevocationKeyPair,
+    R_other: RevocationPublicKey,
+    y_self: PublishingKeyPair,
+    Y_other: PublishingPublicKey,
+    previous_TX_f_output_descriptor: Descriptor<bitcoin::PublicKey>,
+    TX_f: FundingTransaction,
+    sig_TX_f: Signature,
+    TX_c: CommitTransaction,
+    signed_TX_s: SplitTransaction,
+    encsig_TX_c_self: EncryptedSignature,
+    encsig_TX_c_other: EncryptedSignature,
+}
+
+impl State3 {
+    pub async fn next_message(&self) -> anyhow::Result<Message3> {
+        Ok(Message3 {
+            sig_TX_f: self.sig_TX_f.clone(),
+        })
+    }
+
+    /// Returns the Channel and the transaction to broadcast.
+    pub fn receive(
+        self,
+        Message3 {
+            sig_TX_f: sig_TX_f_other,
+        }: Message3,
+    ) -> anyhow::Result<(Channel, Transaction)> {
+        let signed_TX_f = self.TX_f.clone().add_signatures(
+            self.previous_TX_f_output_descriptor,
+            (self.x_self.public(), self.sig_TX_f),
+            (self.X_other.clone(), sig_TX_f_other),
+        )?;
+
+        Ok((
+            Channel {
+                x_self: self.x_self,
+                X_other: self.X_other,
+                final_address_self: self.final_address_self,
+                final_address_other: self.final_address_other,
+                TX_f_body: self.TX_f,
+                current_state: ChannelState {
+                    balance: self.balance,
+                    TX_c: self.TX_c,
+                    encsig_TX_c_self: self.encsig_TX_c_self,
+                    encsig_TX_c_other: self.encsig_TX_c_other,
+                    r_self: self.r_self,
+                    R_other: self.R_other,
+                    y_self: self.y_self,
+                    Y_other: self.Y_other,
+                    signed_TX_s: self.signed_TX_s,
+                },
+                revoked_states: vec![],
+            },
+            signed_TX_f,
+        ))
+    }
+}

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -65,6 +65,26 @@ pub struct FundingTransaction {
     amount_1: Amount,
 }
 
+/// Scenario:
+
+/// Redeem + Funding
+/// Ins:
+/// - HTLC 1BTC
+/// - You: 0.5BTC
+/// Outs:
+/// - Onchain me: 1BTC
+/// - Channel (me: 0BTC, you: 0.5BTC)
+
+/// Atomic swaps in channel
+/// Balance: (me: 0.5BTC, you :0BTC)
+
+/// Rebalance
+/// Ins:
+/// - previous_TXf
+/// [- You: 0.75BTC]
+/// Outs:
+/// [- Onchain me: 0.5 BTC]
+/// - Channel: (me: 0BTC, you: 0.75BTC)
 impl FundingTransaction {
     pub fn new(
         mut args: [(OwnershipPublicKey, PartiallySignedTransaction, Amount); 2],

--- a/thor/tests/e2e.rs
+++ b/thor/tests/e2e.rs
@@ -336,3 +336,351 @@ async fn e2e_force_close_after_updates() {
         "Balance after closing channel should equal balance after opening plus payment, minus transaction fees"
     );
 }
+
+#[tokio::test]
+async fn e2e_channel_recycle() {
+    // Arrange
+
+    let tc_client = testcontainers::clients::Cli::default();
+    let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
+    bitcoind.init(5).await.unwrap();
+
+    let fund_amount = Amount::ONE_BTC;
+    let time_lock = 1;
+
+    let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount).await.unwrap();
+    let (mut alice_transport, mut bob_transport) = make_transports();
+
+    // Act: Create a new channel
+
+    let alice_create = Channel::create(&mut alice_transport, &alice_wallet, fund_amount, time_lock);
+    let bob_create = Channel::create(&mut bob_transport, &bob_wallet, fund_amount, time_lock);
+
+    let (mut alice_channel, mut bob_channel) = futures::future::try_join(alice_create, bob_create)
+        .await
+        .unwrap();
+
+    let after_create_balance_alice = alice_wallet.0.balance().await.unwrap();
+    let after_create_balance_bob = bob_wallet.0.balance().await.unwrap();
+
+    // Assert: Channel balances are synced:
+
+    assert_eq!(alice_channel.balance().ours, bob_channel.balance().theirs);
+    assert_eq!(alice_channel.balance().theirs, bob_channel.balance().ours);
+
+    let Balance {
+        ours: actual_alice_balance,
+        theirs: actual_bob_balance,
+    } = alice_channel.balance();
+
+    // Act: Alice pays Bob 0.1 BTC
+
+    let payment = Amount::from_btc(0.1).unwrap();
+    let expected_alice_balance = actual_alice_balance - payment;
+    let expected_bob_balance = actual_bob_balance + payment;
+
+    let alice_update = alice_channel.update(
+        &mut alice_transport,
+        Balance {
+            ours: expected_alice_balance,
+            theirs: expected_bob_balance,
+        },
+        time_lock,
+    );
+    let bob_update = bob_channel.update(
+        &mut bob_transport,
+        Balance {
+            ours: expected_bob_balance,
+            theirs: expected_alice_balance,
+        },
+        time_lock,
+    );
+
+    futures::future::try_join(alice_update, bob_update)
+        .await
+        .unwrap();
+
+    // Assert: Channel balances are correct
+
+    assert_eq!(expected_alice_balance, alice_channel.balance().ours);
+    assert_eq!(expected_bob_balance, bob_channel.balance().ours);
+
+    assert_eq!(alice_channel.balance().ours, bob_channel.balance().theirs);
+    assert_eq!(alice_channel.balance().theirs, bob_channel.balance().ours);
+
+    let Balance {
+        ours: actual_alice_balance,
+        theirs: actual_bob_balance,
+    } = alice_channel.balance();
+
+    // Act: Recycle the channel
+
+    let alice_recycle = alice_channel.recycle(&mut alice_transport, &alice_wallet);
+    let bob_recycle = bob_channel.recycle(&mut bob_transport, &bob_wallet);
+
+    let (mut alice_channel, mut bob_channel) =
+        futures::future::try_join(alice_recycle, bob_recycle)
+            .await
+            .unwrap();
+
+    // Assert: Channel balances are correct
+
+    assert_eq!(
+        actual_alice_balance - Amount::from_sat(thor::TX_FEE / 2),
+        alice_channel.balance().ours
+    );
+    assert_eq!(
+        actual_bob_balance - Amount::from_sat(thor::TX_FEE / 2),
+        bob_channel.balance().ours
+    );
+
+    assert_eq!(alice_channel.balance().ours, bob_channel.balance().theirs);
+    assert_eq!(alice_channel.balance().theirs, bob_channel.balance().ours);
+
+    let Balance {
+        ours: actual_alice_balance,
+        theirs: actual_bob_balance,
+    } = alice_channel.balance();
+
+    // Act: Bob pays Alice 0.3 BTC
+
+    let payment = Amount::from_btc(0.3).unwrap();
+    let expected_alice_balance = actual_alice_balance + payment;
+    let expected_bob_balance = actual_bob_balance - payment;
+
+    let alice_update = alice_channel.update(
+        &mut alice_transport,
+        Balance {
+            ours: expected_alice_balance,
+            theirs: expected_bob_balance,
+        },
+        time_lock,
+    );
+    let bob_update = bob_channel.update(
+        &mut bob_transport,
+        Balance {
+            ours: expected_bob_balance,
+            theirs: expected_alice_balance,
+        },
+        time_lock,
+    );
+
+    futures::future::try_join(alice_update, bob_update)
+        .await
+        .unwrap();
+
+    // Assert: Channel balances are correct
+
+    assert_eq!(expected_alice_balance, alice_channel.balance().ours);
+    assert_eq!(expected_bob_balance, bob_channel.balance().ours);
+
+    assert_eq!(alice_channel.balance().ours, bob_channel.balance().theirs);
+    assert_eq!(alice_channel.balance().theirs, bob_channel.balance().ours);
+
+    let Balance {
+        ours: actual_alice_balance,
+        theirs: actual_bob_balance,
+    } = alice_channel.balance();
+
+    // Act: Collaboratively close the channel
+
+    let alice_close = alice_channel.close(&mut alice_transport, &alice_wallet);
+    let bob_close = bob_channel.close(&mut bob_transport, &bob_wallet);
+
+    futures::future::try_join(alice_close, bob_close)
+        .await
+        .unwrap();
+
+    let after_close_balance_alice = alice_wallet.0.balance().await.unwrap();
+    let after_close_balance_bob = bob_wallet.0.balance().await.unwrap();
+
+    // We pay half a `thor::TX_FEE` per output in fees for each transaction after
+    // the `FundingTransaction`. Collaboratively closing the channel requires
+    // publishing a single `CloseTransaction`, so each party pays
+    // one half `thor::TX_FEE`, which is deducted from their output.
+    // Note: The `alice/bob_balance` was set after recycling the channel
+    let fee_deduction_per_output = Amount::from_sat(thor::TX_FEE / 2);
+
+    assert_eq!(
+        after_close_balance_alice,
+        after_create_balance_alice + actual_alice_balance - fee_deduction_per_output,
+        "Balance after closing channel should equal balance after opening minus transaction fees"
+    );
+    assert_eq!(
+        after_close_balance_bob,
+        after_create_balance_bob + actual_bob_balance - fee_deduction_per_output,
+        "Balance after closing channel should equal balance after opening minus transaction fees"
+    );
+}
+
+#[tokio::test]
+async fn e2e_channel_recycle_and_force_close() {
+    // Arrange
+
+    let tc_client = testcontainers::clients::Cli::default();
+    let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
+    bitcoind.init(5).await.unwrap();
+
+    let fund_amount = Amount::ONE_BTC;
+    let time_lock = 1;
+
+    let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount).await.unwrap();
+    let (mut alice_transport, mut bob_transport) = make_transports();
+
+    // Act: Create a new channel
+
+    let alice_create = Channel::create(&mut alice_transport, &alice_wallet, fund_amount, time_lock);
+    let bob_create = Channel::create(&mut bob_transport, &bob_wallet, fund_amount, time_lock);
+
+    let (mut alice_channel, mut bob_channel) = futures::future::try_join(alice_create, bob_create)
+        .await
+        .unwrap();
+
+    let after_create_balance_alice = alice_wallet.0.balance().await.unwrap();
+    let after_create_balance_bob = bob_wallet.0.balance().await.unwrap();
+
+    // Assert: Channel balances are synced:
+
+    assert_eq!(alice_channel.balance().ours, bob_channel.balance().theirs);
+    assert_eq!(alice_channel.balance().theirs, bob_channel.balance().ours);
+
+    let Balance {
+        ours: actual_alice_balance,
+        theirs: actual_bob_balance,
+    } = alice_channel.balance();
+
+    // Act: Alice pays Bob 0.1 BTC
+
+    let payment = Amount::from_btc(0.1).unwrap();
+    let expected_alice_balance = actual_alice_balance - payment;
+    let expected_bob_balance = actual_bob_balance + payment;
+
+    let alice_update = alice_channel.update(
+        &mut alice_transport,
+        Balance {
+            ours: expected_alice_balance,
+            theirs: expected_bob_balance,
+        },
+        time_lock,
+    );
+    let bob_update = bob_channel.update(
+        &mut bob_transport,
+        Balance {
+            ours: expected_bob_balance,
+            theirs: expected_alice_balance,
+        },
+        time_lock,
+    );
+
+    futures::future::try_join(alice_update, bob_update)
+        .await
+        .unwrap();
+
+    // Assert: Channel balances are correct
+
+    assert_eq!(expected_alice_balance, alice_channel.balance().ours);
+    assert_eq!(expected_bob_balance, bob_channel.balance().ours);
+
+    assert_eq!(alice_channel.balance().ours, bob_channel.balance().theirs);
+    assert_eq!(alice_channel.balance().theirs, bob_channel.balance().ours);
+
+    let Balance {
+        ours: actual_alice_balance,
+        theirs: actual_bob_balance,
+    } = alice_channel.balance();
+
+    // Act: Recycle the channel
+
+    let alice_recycle = alice_channel.recycle(&mut alice_transport, &alice_wallet);
+    let bob_recycle = bob_channel.recycle(&mut bob_transport, &bob_wallet);
+
+    let (mut alice_channel, mut bob_channel) =
+        futures::future::try_join(alice_recycle, bob_recycle)
+            .await
+            .unwrap();
+
+    // Assert: Channel balances are correct
+
+    assert_eq!(
+        actual_alice_balance - Amount::from_sat(thor::TX_FEE / 2),
+        alice_channel.balance().ours
+    );
+    assert_eq!(
+        actual_bob_balance - Amount::from_sat(thor::TX_FEE / 2),
+        bob_channel.balance().ours
+    );
+
+    assert_eq!(alice_channel.balance().ours, bob_channel.balance().theirs);
+    assert_eq!(alice_channel.balance().theirs, bob_channel.balance().ours);
+
+    let Balance {
+        ours: actual_alice_balance,
+        theirs: actual_bob_balance,
+    } = alice_channel.balance();
+
+    // Act: Bob pays Alice 0.3 BTC
+
+    let payment = Amount::from_btc(0.3).unwrap();
+    let expected_alice_balance = actual_alice_balance + payment;
+    let expected_bob_balance = actual_bob_balance - payment;
+
+    let alice_update = alice_channel.update(
+        &mut alice_transport,
+        Balance {
+            ours: expected_alice_balance,
+            theirs: expected_bob_balance,
+        },
+        time_lock,
+    );
+    let bob_update = bob_channel.update(
+        &mut bob_transport,
+        Balance {
+            ours: expected_bob_balance,
+            theirs: expected_alice_balance,
+        },
+        time_lock,
+    );
+
+    futures::future::try_join(alice_update, bob_update)
+        .await
+        .unwrap();
+
+    // Assert: Channel balances are correct
+
+    assert_eq!(expected_alice_balance, alice_channel.balance().ours);
+    assert_eq!(expected_bob_balance, bob_channel.balance().ours);
+
+    assert_eq!(alice_channel.balance().ours, bob_channel.balance().theirs);
+    assert_eq!(alice_channel.balance().theirs, bob_channel.balance().ours);
+
+    let Balance {
+        ours: actual_alice_balance,
+        theirs: actual_bob_balance,
+    } = alice_channel.balance();
+
+    // Act: Alice forces close the channel
+
+    alice_channel.force_close(&alice_wallet).await.unwrap();
+
+    let after_close_balance_alice = alice_wallet.0.balance().await.unwrap();
+    let after_close_balance_bob = bob_wallet.0.balance().await.unwrap();
+
+    // We pay half a `thor::TX_FEE` per output in fees for each transaction after
+    // the `FundingTransaction`. Force closing the channel requires
+    // publishing two transactions: a `CommitTransaction` and a `SplitTransaction`,
+    // so each party pays a full `thor::TX_FEE`, which is deducted from their
+    // output.
+    // Note: The `actual_{alice,bob}_balance` was set after recycling the channel
+    let fee_deduction_per_output = Amount::from_sat(thor::TX_FEE);
+
+    assert_eq!(
+        after_close_balance_alice,
+        after_create_balance_alice + actual_alice_balance - fee_deduction_per_output,
+        "Balance after closing channel should equal balance after opening minus transaction fees"
+    );
+    assert_eq!(
+        after_close_balance_bob,
+        after_create_balance_bob + actual_bob_balance - fee_deduction_per_output,
+        "Balance after closing channel should equal balance after opening minus transaction fees"
+    );
+}


### PR DESCRIPTION
By recycling a channel, a new funding transaction is pushed on-chain,
spending the previous funding transaction.

In this state, the protocol has little use but the next step would be to
add custom inputs and outputs to this `recycle` transaction to allow
recharging or withdrawing bitcoin from the channel while only spending
the fees of one transaction.

This will be probably be renamed to `rebalance` or `splicing` once said
features are done.