### PR TITLE
Swaps with PTLC as beta ledger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,5 @@ jobs:
         run: cargo check --workspace --all-targets --all-features
 
       - name: Cargo test
-        run: cargo test --workspace --all-features
+        # To avoid stack overflows
+        run: RUST_MIN_STACK=10000000 cargo test --workspace --all-features

--- a/thor/Cargo.toml
+++ b/thor/Cargo.toml
@@ -14,19 +14,21 @@ conquer-once = "0.2"
 ecdsa_fun = { git = "https://github.com/LLFourn/secp256kfun", branch = "thor", features = ["libsecp_compat"] }
 enum-as-inner = "0.3"
 futures = "0.3"
+genawaiter = { version = "0.99", default-features = false, features = ["futures03"] }
 hex = "0.4"
 miniscript = { version = "1.0.0", features = ["compiler"] }
 rand = "0.7"
 serde = { version = "1", features = ["derive"], optional = true }
 sha2 = "0.9"
 thiserror = "1"
+tokio = { version = "0.2", default-features = false, features = ["time"] }
 
 [dev-dependencies]
 bitcoin-harness = { git = "https://github.com/coblox/bitcoin-harness-rs.git", rev = "a695ddc435f5522d7bc35847caf09df85257cc6b" }
 reqwest = { version = "0.10", default-features = false }
 serde_json = "1"
 testcontainers = "0.9"
-tokio = { version = "0.2", default-features = false, features = ["blocking", "macros", "rt-core", "time"] }
+tokio = { version = "0.2", default-features = false, features = ["blocking", "macros", "rt-core", "time", "rt-threaded"] }
 
 [features]
 default = []

--- a/thor/src/protocols/close.rs
+++ b/thor/src/protocols/close.rs
@@ -8,7 +8,7 @@ use bitcoin::{Address, Transaction};
 use ecdsa_fun::Signature;
 
 #[derive(Debug)]
-pub struct State0 {
+pub(crate) struct State0 {
     x_self: OwnershipKeyPair,
     X_other: OwnershipPublicKey,
     TX_f: FundingTransaction,
@@ -24,7 +24,7 @@ pub struct Message0 {
 }
 
 impl State0 {
-    pub fn new(channel: &Channel) -> Self {
+    pub(crate) fn new(channel: &Channel) -> Self {
         Self {
             x_self: channel.x_self.clone(),
             X_other: channel.X_other.clone(),
@@ -35,19 +35,19 @@ impl State0 {
         }
     }
 
-    pub fn compose(&self) -> anyhow::Result<Message0> {
+    pub(crate) fn compose(&self) -> anyhow::Result<Message0> {
         let close_transaction = CloseTransaction::new(&self.TX_f, [
             (self.balance.ours, self.final_address_self.clone()),
             (self.balance.theirs, self.final_address_other.clone()),
         ])?;
-        let sig_close_transaction = close_transaction.sign_once(self.x_self.clone());
+        let sig_close_transaction = close_transaction.sign_once(&self.x_self);
 
         Ok(Message0 {
             sig_close_transaction,
         })
     }
 
-    pub fn interpret(
+    pub(crate) fn interpret(
         self,
         Message0 {
             sig_close_transaction: sig_close_transaction_other,
@@ -62,7 +62,7 @@ impl State0 {
             .verify_sig(self.X_other.clone(), &sig_close_transaction_other)
             .context("failed to verify close transaction signature sent by counterparty")?;
 
-        let sig_close_transaction_self = close_transaction.sign_once(self.x_self.clone());
+        let sig_close_transaction_self = close_transaction.sign_once(&self.x_self);
         let close_transaction = close_transaction.add_signatures(
             (self.x_self.public(), sig_close_transaction_self),
             (self.X_other, sig_close_transaction_other),

--- a/thor/src/protocols/punish.rs
+++ b/thor/src/protocols/punish.rs
@@ -1,37 +1,40 @@
-use crate::{keys::OwnershipKeyPair, transaction::PunishTransaction, ChannelState, RevokedState};
+use crate::{
+    keys::OwnershipKeyPair, transaction::PunishTransaction, RevokedState, StandardChannelState,
+};
 use bitcoin::{Address, Transaction};
 
 #[derive(Copy, Clone, Debug, thiserror::Error)]
 #[error("transaction cannot be punished")]
 pub struct NotOldCommitTransaction;
 
-pub fn punish(
+pub(crate) fn punish(
     x_self: &OwnershipKeyPair,
     revoked_states: &[RevokedState],
     final_address: Address,
     old_commit_transaction: Transaction,
 ) -> anyhow::Result<PunishTransaction> {
-    let RevokedState {
-        channel_state:
-            ChannelState {
-                TX_c,
-                Y_other,
-                encsig_TX_c_self,
-                ..
-            },
-        r_other,
-    } = revoked_states
+    let (channel_state, r_other) = revoked_states
         .iter()
-        .find(|state| state.channel_state.TX_c.txid() == old_commit_transaction.txid())
+        .map(|state| {
+            (
+                StandardChannelState::from(state.channel_state.clone()),
+                state.r_other.clone(),
+            )
+        })
+        .find(|(state, _)| state.TX_c.txid() == old_commit_transaction.txid())
         .ok_or_else(|| NotOldCommitTransaction)?;
+
+    let encsig_TX_c_self = channel_state.encsign_TX_c_self(x_self);
+
+    let StandardChannelState { TX_c, Y_other, .. } = channel_state;
 
     let TX_p = PunishTransaction::new(
         x_self,
         final_address,
         &TX_c,
         &encsig_TX_c_self,
-        &r_other.clone().into(),
-        Y_other.clone(),
+        &r_other.into(),
+        Y_other,
         old_commit_transaction,
     )?;
 

--- a/thor/src/protocols/update.rs
+++ b/thor/src/protocols/update.rs
@@ -3,8 +3,8 @@ use crate::{
         OwnershipKeyPair, OwnershipPublicKey, PublishingKeyPair, PublishingPublicKey,
         RevocationKeyPair, RevocationPublicKey, RevocationSecretKey,
     },
-    transaction::{CommitTransaction, FundingTransaction, SplitTransaction},
-    Channel, ChannelState, RevokedState, SplitOutput,
+    transaction::{balance, ptlc, CommitTransaction, FundingTransaction, SplitTransaction},
+    Channel, ChannelState, Ptlc, RevokedState, SplitOutput, StandardChannelState,
 };
 use anyhow::Context;
 use bitcoin::Address;
@@ -18,21 +18,21 @@ pub struct ShareKeys {
     Y: PublishingPublicKey,
 }
 
-/// Third message of the channel update protocol.
+/// Second message of the channel update protocol.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug)]
 pub struct ShareSplitSignature {
     sig_TX_s: Signature,
 }
 
-/// Fourth message of the channel update protocol.
+/// Third message of the channel update protocol.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug)]
 pub struct ShareCommitEncryptedSignature {
     encsig_TX_c: EncryptedSignature,
 }
 
-/// Fifth and last message of the channel update protocol.
+/// Fourth and last message of the channel update protocol.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug)]
 pub struct RevealRevocationSecretKey {
@@ -87,7 +87,7 @@ impl State0 {
             R: R_other,
             Y: Y_other,
         }: ShareKeys,
-    ) -> anyhow::Result<State1> {
+    ) -> anyhow::Result<State1Kind> {
         let TX_c = CommitTransaction::new(
             &self.TX_f_body,
             [
@@ -100,20 +100,20 @@ impl State0 {
             ],
             self.time_lock,
         )?;
-        let encsig_TX_c_self = TX_c.encsign_once(self.x_self.clone(), Y_other.clone());
+        let encsig_TX_c_self = TX_c.encsign_once(&self.x_self, Y_other.clone());
 
         let TX_s = SplitTransaction::new(&TX_c, self.new_split_outputs.clone())?;
-        let sig_TX_s_self = TX_s.sign_once(self.x_self.clone());
+        let sig_TX_s_self = TX_s.sign_once(&self.x_self);
 
-        Ok(State1 {
-            x_self: self.x_self,
+        let state = State1 {
+            x_self: self.x_self.clone(),
             X_other: self.X_other,
             final_address_self: self.final_address_self,
             final_address_other: self.final_address_other,
             TX_f: self.TX_f_body,
             current_state: self.current_state,
             revoked_states: self.revoked_states,
-            new_split_outputs: self.new_split_outputs,
+            new_split_outputs: self.new_split_outputs.clone(),
             r_self: self.r_self,
             R_other,
             y_self: self.y_self,
@@ -122,13 +122,211 @@ impl State0 {
             TX_s,
             encsig_TX_c_self,
             sig_TX_s_self,
+        };
+
+        // NOTE: We assume that there's only one PTLC output
+        match self
+            .new_split_outputs
+            .into_iter()
+            .find_map(|output| match output {
+                SplitOutput::Ptlc(ptlc) => Some(ptlc),
+                SplitOutput::Balance { .. } => None,
+            }) {
+            None => Ok(State1Kind::State1(state)),
+            Some(ptlc) if ptlc.X_funder == self.x_self.public() => Ok(
+                State1Kind::State1PtlcFunder(State1PtlcFunder::new(state, ptlc)?),
+            ),
+            Some(ptlc) if ptlc.X_redeemer == self.x_self.public() => Ok(
+                State1Kind::State1PtlcRedeemer(State1PtlcRedeemer::new(state, ptlc)?),
+            ),
+            _ => anyhow::bail!("ownership of PTLC output is not shared by X_self"),
+        }
+    }
+}
+
+/// The three possible states in which a party can be in after receiving the
+/// first message.
+///
+/// If a `PtlcOutput` is found among the new `SplitOutput`s for the update,
+/// depending on whether the party is identified as the funder or the redeemer
+/// of said output, the party will transition to `State1PtlcFunder` or
+/// `State1PtlcRedeemer` respectively.
+#[allow(clippy::large_enum_variant)]
+pub enum State1Kind {
+    State1(State1),
+    State1PtlcFunder(State1PtlcFunder),
+    State1PtlcRedeemer(State1PtlcRedeemer),
+}
+
+/// Message sent by the PTLC funder in a channel update protocol execution
+/// involving a PTLC output.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug)]
+pub struct SignaturesPtlcFunder {
+    encsig_TX_ptlc_redeem_funder: EncryptedSignature,
+    sig_TX_ptlc_refund_funder: Signature,
+}
+
+/// Message sent by the PTLC redeemer in a channel update protocol execution
+/// involving a PTLC output.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug)]
+pub struct SignaturesPtlcRedeemer {
+    sig_TX_ptlc_redeem_redeemer: Signature,
+    sig_TX_ptlc_refund_redeemer: Signature,
+}
+
+/// A party who has exchanged `RevocationPublicKey`s and `PublishingPublicKey`s
+/// with the counterparty and is ready to start exchanging signatures for the
+/// `ptlc::RedeemTransaction` and `ptlc::RefundTransaction` involving a PTLC
+/// output which they are funding.
+pub struct State1PtlcFunder {
+    inner: State1,
+    ptlc: Ptlc,
+    TX_ptlc_redeem: ptlc::RedeemTransaction,
+    TX_ptlc_refund: ptlc::RefundTransaction,
+    encsig_TX_ptlc_redeem_funder: EncryptedSignature,
+    sig_TX_ptlc_refund_funder: Signature,
+}
+
+impl State1PtlcFunder {
+    pub fn new(state: State1, ptlc: Ptlc) -> anyhow::Result<Self> {
+        let TX_ptlc_redeem = ptlc::RedeemTransaction::new(
+            &state.TX_s,
+            ptlc.clone(),
+            state.final_address_other.clone(),
+        )?;
+        let encsig_TX_ptlc_redeem_funder = TX_ptlc_redeem.encsign_once(&state.x_self, ptlc.point());
+
+        let TX_ptlc_refund = ptlc::RefundTransaction::new(
+            &state.TX_s,
+            ptlc.clone(),
+            state.final_address_self.clone(),
+        )?;
+        let sig_TX_ptlc_refund_funder = TX_ptlc_refund.sign_once(&state.x_self);
+
+        Ok(Self {
+            inner: state,
+            ptlc,
+            TX_ptlc_redeem,
+            TX_ptlc_refund,
+            encsig_TX_ptlc_redeem_funder,
+            sig_TX_ptlc_refund_funder,
+        })
+    }
+
+    pub fn compose(&self) -> SignaturesPtlcFunder {
+        SignaturesPtlcFunder {
+            encsig_TX_ptlc_redeem_funder: self.encsig_TX_ptlc_redeem_funder.clone(),
+            sig_TX_ptlc_refund_funder: self.sig_TX_ptlc_refund_funder.clone(),
+        }
+    }
+
+    pub fn interpret(
+        mut self,
+        message: SignaturesPtlcRedeemer,
+    ) -> anyhow::Result<WithPtlc<State1>> {
+        self.TX_ptlc_refund
+            .verify_sig(
+                self.inner.X_other.clone(),
+                &message.sig_TX_ptlc_refund_redeemer,
+            )
+            .context("failed to verify sig_TX_ptlc_refund sent by PTLC redeemer")?;
+        self.TX_ptlc_refund.add_signatures(
+            (
+                self.inner.x_self.public(),
+                self.sig_TX_ptlc_refund_funder.clone(),
+            ),
+            (
+                self.inner.X_other.clone(),
+                message.sig_TX_ptlc_refund_redeemer.clone(),
+            ),
+        )?;
+
+        Ok(WithPtlc {
+            state: self.inner,
+            ptlc: self.ptlc,
+            TX_ptlc_redeem: self.TX_ptlc_redeem,
+            TX_ptlc_refund: self.TX_ptlc_refund,
+            encsig_TX_ptlc_redeem_funder: self.encsig_TX_ptlc_redeem_funder,
+            sig_TX_ptlc_redeem_redeemer: message.sig_TX_ptlc_redeem_redeemer,
+            sig_TX_ptlc_refund_funder: self.sig_TX_ptlc_refund_funder,
+            sig_TX_ptlc_refund_redeemer: message.sig_TX_ptlc_refund_redeemer,
+        })
+    }
+}
+
+/// A party who has exchanged `RevocationPublicKey`s and `PublishingPublicKey`s
+/// with the counterparty and is ready to start exchanging signatures for the
+/// `ptlc::RedeemTransaction` and `ptlc::RefundTransaction` involving a PTLC
+/// output which they are redeeming.
+pub struct State1PtlcRedeemer {
+    inner: State1,
+    ptlc: Ptlc,
+    TX_ptlc_redeem: ptlc::RedeemTransaction,
+    TX_ptlc_refund: ptlc::RefundTransaction,
+    sig_TX_ptlc_redeem_redeemer: Signature,
+    sig_TX_ptlc_refund_redeemer: Signature,
+}
+
+impl State1PtlcRedeemer {
+    pub fn new(state: State1, ptlc: Ptlc) -> anyhow::Result<Self> {
+        let TX_ptlc_redeem = ptlc::RedeemTransaction::new(
+            &state.TX_s,
+            ptlc.clone(),
+            state.final_address_self.clone(),
+        )?;
+        let sig_TX_ptlc_redeem_redeemer = TX_ptlc_redeem.sign_once(&state.x_self);
+
+        let TX_ptlc_refund = ptlc::RefundTransaction::new(
+            &state.TX_s,
+            ptlc.clone(),
+            state.final_address_other.clone(),
+        )?;
+        let sig_TX_ptlc_refund_redeemer = TX_ptlc_refund.sign_once(&state.x_self);
+
+        Ok(Self {
+            inner: state,
+            ptlc,
+            TX_ptlc_redeem,
+            TX_ptlc_refund,
+            sig_TX_ptlc_redeem_redeemer,
+            sig_TX_ptlc_refund_redeemer,
+        })
+    }
+
+    pub fn compose(&self) -> SignaturesPtlcRedeemer {
+        SignaturesPtlcRedeemer {
+            sig_TX_ptlc_redeem_redeemer: self.sig_TX_ptlc_redeem_redeemer.clone(),
+            sig_TX_ptlc_refund_redeemer: self.sig_TX_ptlc_refund_redeemer.clone(),
+        }
+    }
+
+    pub fn interpret(self, message: SignaturesPtlcFunder) -> anyhow::Result<WithPtlc<State1>> {
+        self.TX_ptlc_redeem
+            .verify_encsig(
+                self.inner.X_other.clone(),
+                self.ptlc.point().into(),
+                &message.encsig_TX_ptlc_redeem_funder,
+            )
+            .context("failed to verify encsig_TX_ptlc_redeem sent by PTLC funder")?;
+
+        Ok(WithPtlc {
+            state: self.inner,
+            ptlc: self.ptlc,
+            TX_ptlc_redeem: self.TX_ptlc_redeem,
+            TX_ptlc_refund: self.TX_ptlc_refund,
+            encsig_TX_ptlc_redeem_funder: message.encsig_TX_ptlc_redeem_funder,
+            sig_TX_ptlc_redeem_redeemer: self.sig_TX_ptlc_redeem_redeemer,
+            sig_TX_ptlc_refund_funder: message.sig_TX_ptlc_refund_funder,
+            sig_TX_ptlc_refund_redeemer: self.sig_TX_ptlc_refund_redeemer,
         })
     }
 }
 
 /// A party who has exchanged `RevocationPublicKey`s and `PublishingPublicKey`s
 /// with the counterparty and is ready to start exchanging signatures.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct State1 {
     x_self: OwnershipKeyPair,
     X_other: OwnershipPublicKey,
@@ -280,7 +478,9 @@ pub struct State3 {
 impl State3 {
     pub fn compose(&self) -> RevealRevocationSecretKey {
         RevealRevocationSecretKey {
-            r: self.current_state.r_self.clone().into(),
+            r: StandardChannelState::from(self.current_state.clone())
+                .r_self
+                .into(),
         }
     }
 
@@ -288,7 +488,7 @@ impl State3 {
         self,
         RevealRevocationSecretKey { r: r_other }: RevealRevocationSecretKey,
     ) -> anyhow::Result<Channel> {
-        self.current_state
+        StandardChannelState::from(self.current_state.clone())
             .R_other
             .verify_revocation_secret_key(&r_other)?;
 
@@ -299,17 +499,20 @@ impl State3 {
         let mut revoked_states = self.revoked_states;
         revoked_states.push(revoked_state);
 
-        let current_state = ChannelState {
-            split_outputs: self.new_split_outputs,
+        let current_state = ChannelState::Standard(StandardChannelState {
+            balance: balance(
+                self.new_split_outputs,
+                &self.final_address_self,
+                &self.final_address_other,
+            ),
             TX_c: self.TX_c,
-            encsig_TX_c_self: self.encsig_TX_c_self,
             encsig_TX_c_other: self.encsig_TX_c_other,
             r_self: self.r_self,
             R_other: self.R_other,
             y_self: self.y_self,
             Y_other: self.Y_other,
             signed_TX_s: self.signed_TX_s,
-        };
+        });
 
         Ok(Channel {
             x_self: self.x_self,
@@ -320,5 +523,87 @@ impl State3 {
             current_state,
             revoked_states,
         })
+    }
+}
+
+#[derive(Clone)]
+pub struct WithPtlc<S> {
+    state: S,
+    ptlc: Ptlc,
+    TX_ptlc_redeem: ptlc::RedeemTransaction,
+    TX_ptlc_refund: ptlc::RefundTransaction,
+    encsig_TX_ptlc_redeem_funder: EncryptedSignature,
+    sig_TX_ptlc_redeem_redeemer: Signature,
+    sig_TX_ptlc_refund_funder: Signature,
+    sig_TX_ptlc_refund_redeemer: Signature,
+}
+
+impl WithPtlc<State1> {
+    pub fn compose(&self) -> ShareSplitSignature {
+        self.state.compose()
+    }
+
+    pub fn interpret(self, message: ShareSplitSignature) -> anyhow::Result<WithPtlc<State2>> {
+        let state = self.state.interpret(message)?;
+
+        Ok(WithPtlc {
+            state,
+            ptlc: self.ptlc,
+            TX_ptlc_redeem: self.TX_ptlc_redeem,
+            TX_ptlc_refund: self.TX_ptlc_refund,
+            encsig_TX_ptlc_redeem_funder: self.encsig_TX_ptlc_redeem_funder,
+            sig_TX_ptlc_redeem_redeemer: self.sig_TX_ptlc_redeem_redeemer,
+            sig_TX_ptlc_refund_funder: self.sig_TX_ptlc_refund_funder,
+            sig_TX_ptlc_refund_redeemer: self.sig_TX_ptlc_refund_redeemer,
+        })
+    }
+}
+
+impl WithPtlc<State2> {
+    pub fn compose(&self) -> ShareCommitEncryptedSignature {
+        self.state.compose()
+    }
+
+    pub fn interpret(
+        self,
+        message: ShareCommitEncryptedSignature,
+    ) -> anyhow::Result<WithPtlc<State3>> {
+        let state = self.state.interpret(message)?;
+
+        Ok(WithPtlc {
+            state,
+            ptlc: self.ptlc,
+            TX_ptlc_redeem: self.TX_ptlc_redeem,
+            TX_ptlc_refund: self.TX_ptlc_refund,
+            encsig_TX_ptlc_redeem_funder: self.encsig_TX_ptlc_redeem_funder,
+            sig_TX_ptlc_redeem_redeemer: self.sig_TX_ptlc_redeem_redeemer,
+            sig_TX_ptlc_refund_funder: self.sig_TX_ptlc_refund_funder,
+            sig_TX_ptlc_refund_redeemer: self.sig_TX_ptlc_refund_redeemer,
+        })
+    }
+}
+
+impl WithPtlc<State3> {
+    pub fn compose(&self) -> RevealRevocationSecretKey {
+        self.state.compose()
+    }
+
+    pub fn interpret(self, message: RevealRevocationSecretKey) -> anyhow::Result<Channel> {
+        let mut channel = self.state.interpret(message)?;
+
+        let current_state = ChannelState::WithPtlc {
+            inner: channel.current_state.into(),
+            ptlc: self.ptlc,
+            TX_ptlc_redeem: self.TX_ptlc_redeem,
+            TX_ptlc_refund: self.TX_ptlc_refund,
+            encsig_TX_ptlc_redeem_funder: self.encsig_TX_ptlc_redeem_funder,
+            sig_TX_ptlc_redeem_redeemer: self.sig_TX_ptlc_redeem_redeemer,
+            sig_TX_ptlc_refund_funder: self.sig_TX_ptlc_refund_funder,
+            sig_TX_ptlc_refund_redeemer: self.sig_TX_ptlc_refund_redeemer,
+        };
+
+        channel.current_state = current_state;
+
+        Ok(channel)
     }
 }

--- a/thor/src/signature.rs
+++ b/thor/src/signature.rs
@@ -1,7 +1,8 @@
-use crate::keys::{OwnershipPublicKey, PublishingPublicKey, PublishingSecretKey};
+use crate::keys::OwnershipPublicKey;
 use bitcoin::hashes::Hash;
 use ecdsa_fun::{
     adaptor::{Adaptor, EncryptedSignature},
+    fun::{Point, Scalar},
     nonce::Deterministic,
     Signature, ECDSA,
 };
@@ -37,7 +38,7 @@ pub struct InvalidEncryptedSignature;
 
 pub fn verify_encsig(
     verification_key: OwnershipPublicKey,
-    encryption_key: PublishingPublicKey,
+    encryption_key: Point,
     transaction_sighash: &SigHash,
     encsig: &EncryptedSignature,
 ) -> Result<(), InvalidEncryptedSignature> {
@@ -45,7 +46,7 @@ pub fn verify_encsig(
 
     if adaptor.verify_encrypted_signature(
         &verification_key.into(),
-        &encryption_key.into(),
+        &encryption_key,
         &transaction_sighash.into_inner(),
         &encsig,
     ) {
@@ -56,8 +57,8 @@ pub fn verify_encsig(
 }
 
 #[allow(dead_code)]
-pub fn decrypt(decryption_key: PublishingSecretKey, encsig: EncryptedSignature) -> Signature {
+pub fn decrypt(decryption_key: Scalar, encsig: EncryptedSignature) -> Signature {
     let adaptor = Adaptor::<Sha256, Deterministic<Sha256>>::default();
 
-    adaptor.decrypt_signature(&decryption_key.into(), encsig)
+    adaptor.decrypt_signature(&decryption_key, encsig)
 }

--- a/thor/src/transaction/ptlc.rs
+++ b/thor/src/transaction/ptlc.rs
@@ -1,0 +1,215 @@
+use crate::{
+    keys::{OwnershipKeyPair, OwnershipPublicKey},
+    signature,
+    transaction::{build_shared_output_descriptor, SplitTransaction},
+    Ptlc, PtlcPoint, TX_FEE,
+};
+
+use bitcoin::{
+    util::bip143::SighashComponents, Address, OutPoint, Script, SigHash, Transaction, TxIn, TxOut,
+};
+use ecdsa_fun::{self, adaptor::EncryptedSignature, fun::Point, Signature};
+use miniscript::Descriptor;
+use signature::{verify_encsig, verify_sig};
+use std::collections::HashMap;
+
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(Clone, Debug)]
+pub(crate) struct RedeemTransaction {
+    inner: Transaction,
+    digest: SigHash,
+    input_descriptor: Descriptor<bitcoin::PublicKey>,
+}
+
+impl RedeemTransaction {
+    pub fn new(
+        TX_s: &SplitTransaction,
+        ptlc: Ptlc,
+        redeem_address: Address,
+    ) -> anyhow::Result<Self> {
+        let (transaction, digest, input_descriptor) =
+            spend_transaction(TX_s, ptlc, redeem_address, 0xFFFF_FFFF)?;
+
+        Ok(Self {
+            inner: transaction,
+            digest,
+            input_descriptor,
+        })
+    }
+
+    pub fn sign_once(&self, x_self: &OwnershipKeyPair) -> Signature {
+        x_self.sign(self.digest)
+    }
+
+    pub fn encsign_once(&self, x_self: &OwnershipKeyPair, point: PtlcPoint) -> EncryptedSignature {
+        x_self.encsign(point.into(), self.digest)
+    }
+
+    pub fn add_signatures(
+        &self,
+        (X_0, sig_0): (OwnershipPublicKey, Signature),
+        (X_1, sig_1): (OwnershipPublicKey, Signature),
+    ) -> anyhow::Result<Transaction> {
+        let satisfier = {
+            let mut satisfier = HashMap::with_capacity(2);
+
+            let X_0 = ::bitcoin::PublicKey {
+                compressed: true,
+                key: X_0.into(),
+            };
+            let X_1 = ::bitcoin::PublicKey {
+                compressed: true,
+                key: X_1.into(),
+            };
+
+            // The order in which these are inserted doesn't matter
+            satisfier.insert(X_0, (sig_0.into(), ::bitcoin::SigHashType::All));
+            satisfier.insert(X_1, (sig_1.into(), ::bitcoin::SigHashType::All));
+
+            satisfier
+        };
+
+        let mut transaction = self.inner.clone();
+
+        self.input_descriptor
+            .satisfy(&mut transaction.input[0], satisfier)?;
+
+        Ok(transaction)
+    }
+
+    pub fn verify_encsig(
+        &self,
+        verification_key: OwnershipPublicKey,
+        encryption_key: Point,
+        encsig: &EncryptedSignature,
+    ) -> anyhow::Result<()> {
+        verify_encsig(verification_key, encryption_key, &self.digest, encsig)?;
+
+        Ok(())
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(Clone, Debug)]
+pub(crate) struct RefundTransaction {
+    inner: Transaction,
+    digest: SigHash,
+    input_descriptor: Descriptor<bitcoin::PublicKey>,
+}
+
+impl RefundTransaction {
+    pub fn new(
+        TX_s: &SplitTransaction,
+        ptlc: Ptlc,
+        refund_address: Address,
+    ) -> anyhow::Result<Self> {
+        let (transaction, digest, input_descriptor) =
+            spend_transaction(TX_s, ptlc.clone(), refund_address, ptlc.refund_time_lock)?;
+
+        Ok(Self {
+            inner: transaction,
+            digest,
+            input_descriptor,
+        })
+    }
+
+    pub fn sign_once(&self, x_self: &OwnershipKeyPair) -> Signature {
+        x_self.sign(self.digest)
+    }
+
+    pub fn verify_sig(
+        &self,
+        verification_key: OwnershipPublicKey,
+        signature: &Signature,
+    ) -> anyhow::Result<()> {
+        verify_sig(verification_key, &self.digest, signature)?;
+
+        Ok(())
+    }
+
+    pub fn add_signatures(
+        &mut self,
+        (X_0, sig_0): (OwnershipPublicKey, Signature),
+        (X_1, sig_1): (OwnershipPublicKey, Signature),
+    ) -> anyhow::Result<()> {
+        let satisfier = {
+            let mut satisfier = HashMap::with_capacity(2);
+
+            let X_0 = ::bitcoin::PublicKey {
+                compressed: true,
+                key: X_0.into(),
+            };
+            let X_1 = ::bitcoin::PublicKey {
+                compressed: true,
+                key: X_1.into(),
+            };
+
+            // The order in which these are inserted doesn't matter
+            satisfier.insert(X_0, (sig_0.into(), ::bitcoin::SigHashType::All));
+            satisfier.insert(X_1, (sig_1.into(), ::bitcoin::SigHashType::All));
+
+            satisfier
+        };
+
+        let mut transaction = self.inner.clone();
+
+        self.input_descriptor
+            .satisfy(&mut transaction.input[0], satisfier)?;
+
+        Ok(())
+    }
+}
+
+pub(crate) fn spend_transaction(
+    TX_s: &SplitTransaction,
+    ptlc: Ptlc,
+    refund_address: Address,
+    input_sequence: u32,
+) -> anyhow::Result<(Transaction, SigHash, Descriptor<bitcoin::PublicKey>)> {
+    let mut Xs = [ptlc.X_funder, ptlc.X_redeemer];
+    Xs.sort_by(|a, b| a.partial_cmp(b).expect("comparison is possible"));
+    let [X_0, X_1] = Xs;
+    let ptlc_output_descriptor = build_shared_output_descriptor(X_0, X_1);
+
+    let vout = TX_s
+        .inner
+        .output
+        .iter()
+        .position(|output| output.script_pubkey == ptlc_output_descriptor.script_pubkey())
+        .ok_or_else(|| anyhow::anyhow!("TX_s does not contain PTLC output"))?;
+
+    #[allow(clippy::cast_possible_truncation)]
+    let input = TxIn {
+        previous_output: OutPoint::new(TX_s.txid(), vout as u32),
+        script_sig: Script::new(),
+        sequence: input_sequence,
+        witness: Vec::new(),
+    };
+
+    let ptlc_output_value = TX_s.inner.output[vout].value;
+    let output = TxOut {
+        value: ptlc_output_value - TX_FEE,
+        script_pubkey: refund_address.script_pubkey(),
+    };
+
+    let transaction = Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![input.clone()],
+        output: vec![output],
+    };
+
+    let digest = SighashComponents::new(&transaction).sighash_all(
+        &input,
+        &ptlc_output_descriptor.witness_script(),
+        ptlc_output_value,
+    );
+
+    Ok((transaction, digest, ptlc_output_descriptor))
+}
+
+impl From<RefundTransaction> for Transaction {
+    fn from(from: RefundTransaction) -> Self {
+        from.inner
+    }
+}

--- a/thor/tests/e2e.rs
+++ b/thor/tests/e2e.rs
@@ -4,28 +4,17 @@ mod harness;
 
 use bitcoin::Amount;
 use bitcoin_harness::{self, Bitcoind};
-use harness::{make_transports, make_wallets};
-use thor::{Balance, Channel};
+use genawaiter::GeneratorState;
+use harness::{build_runtime, generate_balances, make_transports, make_wallets, Transport};
+use thor::{Balance, Channel, PtlcPoint, PtlcSecret};
 
-fn generate_balances(fund_amount_alice: Amount, fund_amount_bob: Amount) -> (Balance, Balance) {
-    let balance_alice = Balance {
-        ours: fund_amount_alice,
-        theirs: fund_amount_bob,
-    };
+#[test]
+fn e2e_channel_creation() {
+    let mut runtime = build_runtime();
 
-    let balance_bob = Balance {
-        ours: fund_amount_bob,
-        theirs: fund_amount_alice,
-    };
-
-    (balance_alice, balance_bob)
-}
-
-#[tokio::test]
-async fn e2e_channel_creation() {
     let tc_client = testcontainers::clients::Cli::default();
     let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
-    bitcoind.init(5).await.unwrap();
+    runtime.block_on(bitcoind.init(5)).unwrap();
 
     let fund_amount_alice = Amount::ONE_BTC;
     let fund_amount_bob = Amount::ONE_BTC;
@@ -33,8 +22,8 @@ async fn e2e_channel_creation() {
 
     let time_lock = 1;
 
-    let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob)
-        .await
+    let (alice_wallet, bob_wallet) = runtime
+        .block_on(make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob))
         .unwrap();
     let (mut alice_transport, mut bob_transport) = make_transports();
 
@@ -46,16 +35,18 @@ async fn e2e_channel_creation() {
     );
     let bob_create = Channel::create(&mut bob_transport, &bob_wallet, balance_bob, time_lock);
 
-    let (_alice_channel, _bob_channel) = futures::future::try_join(alice_create, bob_create)
-        .await
+    let (_alice_channel, _bob_channel) = runtime
+        .block_on(futures::future::try_join(alice_create, bob_create))
         .unwrap();
 }
 
-#[tokio::test]
-async fn e2e_channel_update() {
+#[test]
+fn e2e_channel_update() {
+    let mut runtime = build_runtime();
+
     let tc_client = testcontainers::clients::Cli::default();
     let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
-    bitcoind.init(5).await.unwrap();
+    runtime.block_on(bitcoind.init(5)).unwrap();
 
     let fund_amount_alice = Amount::ONE_BTC;
     let fund_amount_bob = Amount::ONE_BTC;
@@ -63,8 +54,8 @@ async fn e2e_channel_update() {
 
     let time_lock = 1;
 
-    let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob)
-        .await
+    let (alice_wallet, bob_wallet) = runtime
+        .block_on(make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob))
         .unwrap();
     let (mut alice_transport, mut bob_transport) = make_transports();
 
@@ -76,8 +67,8 @@ async fn e2e_channel_update() {
     );
     let bob_create = Channel::create(&mut bob_transport, &bob_wallet, balance_bob, time_lock);
 
-    let (mut alice_channel, mut bob_channel) = futures::future::try_join(alice_create, bob_create)
-        .await
+    let (mut alice_channel, mut bob_channel) = runtime
+        .block_on(futures::future::try_join(alice_create, bob_create))
         .unwrap();
 
     // Parties agree on a new channel balance: Alice pays 0.5 a Bitcoin to Bob
@@ -85,7 +76,7 @@ async fn e2e_channel_update() {
     let alice_balance = fund_amount_alice - payment;
     let bob_balance = fund_amount_bob + payment;
 
-    let alice_update = alice_channel.update(
+    let alice_update = alice_channel.update_balance(
         &mut alice_transport,
         Balance {
             ours: alice_balance,
@@ -93,7 +84,7 @@ async fn e2e_channel_update() {
         },
         time_lock,
     );
-    let bob_update = bob_channel.update(
+    let bob_update = bob_channel.update_balance(
         &mut bob_transport,
         Balance {
             ours: bob_balance,
@@ -102,8 +93,8 @@ async fn e2e_channel_update() {
         time_lock,
     );
 
-    futures::future::try_join(alice_update, bob_update)
-        .await
+    runtime
+        .block_on(futures::future::try_join(alice_update, bob_update))
         .unwrap();
 
     // Assert expected balance changes
@@ -115,11 +106,13 @@ async fn e2e_channel_update() {
     assert_eq!(bob_channel.balance().theirs, alice_balance);
 }
 
-#[tokio::test]
-async fn e2e_punish_publication_of_revoked_commit_transaction() {
+#[test]
+fn e2e_punish_publication_of_revoked_commit_transaction() {
+    let mut runtime = build_runtime();
+
     let tc_client = testcontainers::clients::Cli::default();
     let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
-    bitcoind.init(5).await.unwrap();
+    runtime.block_on(bitcoind.init(5)).unwrap();
 
     let fund_amount_alice = Amount::ONE_BTC;
     let fund_amount_bob = Amount::ONE_BTC;
@@ -127,8 +120,8 @@ async fn e2e_punish_publication_of_revoked_commit_transaction() {
 
     let time_lock = 1;
 
-    let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob)
-        .await
+    let (alice_wallet, bob_wallet) = runtime
+        .block_on(make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob))
         .unwrap();
     let (mut alice_transport, mut bob_transport) = make_transports();
 
@@ -140,19 +133,19 @@ async fn e2e_punish_publication_of_revoked_commit_transaction() {
     );
     let bob_create = Channel::create(&mut bob_transport, &bob_wallet, balance_bob, time_lock);
 
-    let (mut alice_channel, mut bob_channel) = futures::future::try_join(alice_create, bob_create)
-        .await
+    let (mut alice_channel, mut bob_channel) = runtime
+        .block_on(futures::future::try_join(alice_create, bob_create))
         .unwrap();
 
-    let after_open_balance_alice = alice_wallet.0.balance().await.unwrap();
-    let after_open_balance_bob = bob_wallet.0.balance().await.unwrap();
+    let after_open_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
+    let after_open_balance_bob = runtime.block_on(bob_wallet.0.balance()).unwrap();
 
     // Parties agree on a new channel balance: Alice pays 0.5 a Bitcoin to Bob
     let payment = Amount::from_btc(0.5).unwrap();
     let alice_balance = fund_amount_alice - payment;
     let bob_balance = fund_amount_bob + payment;
 
-    let alice_update = alice_channel.update(
+    let alice_update = alice_channel.update_balance(
         &mut alice_transport,
         Balance {
             ours: alice_balance,
@@ -160,7 +153,7 @@ async fn e2e_punish_publication_of_revoked_commit_transaction() {
         },
         time_lock,
     );
-    let bob_update = bob_channel.update(
+    let bob_update = bob_channel.update_balance(
         &mut bob_transport,
         Balance {
             ours: bob_balance,
@@ -169,28 +162,29 @@ async fn e2e_punish_publication_of_revoked_commit_transaction() {
         time_lock,
     );
 
-    futures::future::try_join(alice_update, bob_update)
-        .await
+    runtime
+        .block_on(futures::future::try_join(alice_update, bob_update))
         .unwrap();
 
     // Alice attempts to cheat by publishing a revoked commit transaction
 
     let signed_revoked_TX_c = alice_channel.latest_revoked_signed_TX_c().unwrap().unwrap();
-    alice_wallet
-        .0
-        .send_raw_transaction(signed_revoked_TX_c.clone())
-        .await
+    runtime
+        .block_on(
+            alice_wallet
+                .0
+                .send_raw_transaction(signed_revoked_TX_c.clone()),
+        )
         .unwrap();
 
     // Bob sees the transaction and punishes Alice
 
-    bob_channel
-        .punish(&bob_wallet, signed_revoked_TX_c)
-        .await
+    runtime
+        .block_on(bob_channel.punish(&bob_wallet, signed_revoked_TX_c))
         .unwrap();
 
-    let after_punish_balance_alice = alice_wallet.0.balance().await.unwrap();
-    let after_punish_balance_bob = bob_wallet.0.balance().await.unwrap();
+    let after_punish_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
+    let after_punish_balance_bob = runtime.block_on(bob_wallet.0.balance()).unwrap();
 
     assert_eq!(
         after_punish_balance_alice, after_open_balance_alice,
@@ -203,11 +197,13 @@ async fn e2e_punish_publication_of_revoked_commit_transaction() {
     );
 }
 
-#[tokio::test]
-async fn e2e_channel_collaborative_close() {
+#[test]
+fn e2e_channel_collaborative_close() {
+    let mut runtime = build_runtime();
+
     let tc_client = testcontainers::clients::Cli::default();
     let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
-    bitcoind.init(5).await.unwrap();
+    runtime.block_on(bitcoind.init(5)).unwrap();
 
     let fund_amount_alice = Amount::ONE_BTC;
     let fund_amount_bob = Amount::ONE_BTC;
@@ -215,8 +211,8 @@ async fn e2e_channel_collaborative_close() {
 
     let time_lock = 1;
 
-    let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob)
-        .await
+    let (alice_wallet, bob_wallet) = runtime
+        .block_on(make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob))
         .unwrap();
     let (mut alice_transport, mut bob_transport) = make_transports();
 
@@ -228,22 +224,22 @@ async fn e2e_channel_collaborative_close() {
     );
     let bob_create = Channel::create(&mut bob_transport, &bob_wallet, balance_bob, time_lock);
 
-    let (mut alice_channel, mut bob_channel) = futures::future::try_join(alice_create, bob_create)
-        .await
+    let (alice_channel, bob_channel) = runtime
+        .block_on(futures::future::try_join(alice_create, bob_create))
         .unwrap();
 
-    let after_open_balance_alice = alice_wallet.0.balance().await.unwrap();
-    let after_open_balance_bob = bob_wallet.0.balance().await.unwrap();
+    let after_open_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
+    let after_open_balance_bob = runtime.block_on(bob_wallet.0.balance()).unwrap();
 
     let alice_close = alice_channel.close(&mut alice_transport, &alice_wallet);
     let bob_close = bob_channel.close(&mut bob_transport, &bob_wallet);
 
-    futures::future::try_join(alice_close, bob_close)
-        .await
+    runtime
+        .block_on(futures::future::try_join(alice_close, bob_close))
         .unwrap();
 
-    let after_close_balance_alice = alice_wallet.0.balance().await.unwrap();
-    let after_close_balance_bob = bob_wallet.0.balance().await.unwrap();
+    let after_close_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
+    let after_close_balance_bob = runtime.block_on(bob_wallet.0.balance()).unwrap();
 
     // We pay half a `thor::TX_FEE` per output in fees for each transaction after
     // the `FundingTransaction`. Collaboratively closing the channel requires
@@ -263,11 +259,13 @@ async fn e2e_channel_collaborative_close() {
     );
 }
 
-#[tokio::test]
-async fn e2e_force_close_channel() {
+#[test]
+fn e2e_force_close_channel() {
+    let mut runtime = build_runtime();
+
     let tc_client = testcontainers::clients::Cli::default();
     let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
-    bitcoind.init(5).await.unwrap();
+    runtime.block_on(bitcoind.init(5)).unwrap();
 
     let fund_amount_alice = Amount::ONE_BTC;
     let fund_amount_bob = Amount::ONE_BTC;
@@ -275,8 +273,8 @@ async fn e2e_force_close_channel() {
 
     let time_lock = 1;
 
-    let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob)
-        .await
+    let (alice_wallet, bob_wallet) = runtime
+        .block_on(make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob))
         .unwrap();
     let (mut alice_transport, mut bob_transport) = make_transports();
 
@@ -288,17 +286,19 @@ async fn e2e_force_close_channel() {
     );
     let bob_create = Channel::create(&mut bob_transport, &bob_wallet, balance_bob, time_lock);
 
-    let (mut alice_channel, _bob_channel) = futures::future::try_join(alice_create, bob_create)
-        .await
+    let (alice_channel, _bob_channel) = runtime
+        .block_on(futures::future::try_join(alice_create, bob_create))
         .unwrap();
 
-    let after_open_balance_alice = alice_wallet.0.balance().await.unwrap();
-    let after_open_balance_bob = bob_wallet.0.balance().await.unwrap();
+    let after_open_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
+    let after_open_balance_bob = runtime.block_on(bob_wallet.0.balance()).unwrap();
 
-    alice_channel.force_close(&alice_wallet).await.unwrap();
+    runtime
+        .block_on(alice_channel.force_close(&alice_wallet))
+        .unwrap();
 
-    let after_close_balance_alice = alice_wallet.0.balance().await.unwrap();
-    let after_close_balance_bob = bob_wallet.0.balance().await.unwrap();
+    let after_close_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
+    let after_close_balance_bob = runtime.block_on(bob_wallet.0.balance()).unwrap();
 
     // We pay half a `thor::TX_FEE` per output in fees for each transaction after
     // the `FundingTransaction`. Force closing the channel requires publishing
@@ -318,13 +318,15 @@ async fn e2e_force_close_channel() {
     );
 }
 
-#[tokio::test]
-async fn e2e_force_close_after_updates() {
+#[test]
+fn e2e_force_close_after_updates() {
+    let mut runtime = build_runtime();
+
     // Arrange:
 
     let tc_client = testcontainers::clients::Cli::default();
     let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
-    bitcoind.init(5).await.unwrap();
+    runtime.block_on(bitcoind.init(5)).unwrap();
 
     let fund_amount_alice = Amount::ONE_BTC;
     let fund_amount_bob = Amount::ONE_BTC;
@@ -332,8 +334,8 @@ async fn e2e_force_close_after_updates() {
 
     let time_lock = 1;
 
-    let (alice_wallet, bob_wallet) = make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob)
-        .await
+    let (alice_wallet, bob_wallet) = runtime
+        .block_on(make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob))
         .unwrap();
     let (mut alice_transport, mut bob_transport) = make_transports();
 
@@ -349,12 +351,12 @@ async fn e2e_force_close_after_updates() {
     );
     let bob_create = Channel::create(&mut bob_transport, &bob_wallet, balance_bob, time_lock);
 
-    let (mut alice_channel, mut bob_channel) = futures::future::try_join(alice_create, bob_create)
-        .await
+    let (mut alice_channel, mut bob_channel) = runtime
+        .block_on(futures::future::try_join(alice_create, bob_create))
         .unwrap();
 
-    let after_create_balance_alice = alice_wallet.0.balance().await.unwrap();
-    let after_create_balance_bob = bob_wallet.0.balance().await.unwrap();
+    let after_create_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
+    let after_create_balance_bob = runtime.block_on(bob_wallet.0.balance()).unwrap();
 
     // Alice pays Bob 0.1 BTC
 
@@ -362,7 +364,7 @@ async fn e2e_force_close_after_updates() {
     let alice_balance = fund_amount_alice - payment;
     let bob_balance = fund_amount_bob + payment;
 
-    let alice_update = alice_channel.update(
+    let alice_update = alice_channel.update_balance(
         &mut alice_transport,
         Balance {
             ours: alice_balance,
@@ -370,7 +372,7 @@ async fn e2e_force_close_after_updates() {
         },
         time_lock,
     );
-    let bob_update = bob_channel.update(
+    let bob_update = bob_channel.update_balance(
         &mut bob_transport,
         Balance {
             ours: bob_balance,
@@ -379,18 +381,20 @@ async fn e2e_force_close_after_updates() {
         time_lock,
     );
 
-    futures::future::try_join(alice_update, bob_update)
-        .await
+    runtime
+        .block_on(futures::future::try_join(alice_update, bob_update))
         .unwrap();
 
     // Alice force closes the channel
 
-    alice_channel.force_close(&alice_wallet).await.unwrap();
+    runtime
+        .block_on(alice_channel.force_close(&alice_wallet))
+        .unwrap();
 
     // Assert:
 
-    let after_close_balance_alice = alice_wallet.0.balance().await.unwrap();
-    let after_close_balance_bob = bob_wallet.0.balance().await.unwrap();
+    let after_close_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
+    let after_close_balance_bob = runtime.block_on(bob_wallet.0.balance()).unwrap();
 
     // We pay half a `thor::TX_FEE` per output in fees for each transaction after
     // the `FundingTransaction`. Force closing the channel requires
@@ -409,4 +413,250 @@ async fn e2e_force_close_after_updates() {
         after_create_balance_bob + fund_amount_bob + payment - fee_deduction_per_output,
         "Balance after closing channel should equal balance after opening plus payment, minus transaction fees"
     );
+}
+
+// TODO: Fund alpha ledger (Bitcoin on-chain) and use the secret to redeem it as
+// Bob
+#[test]
+fn e2e_atomic_swap_happy() {
+    let mut runtime = build_runtime();
+
+    let tc_client = testcontainers::clients::Cli::default();
+    let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
+    runtime.block_on(bitcoind.init(5)).unwrap();
+
+    let fund_amount_alice = Amount::ONE_BTC;
+    let fund_amount_bob = Amount::ONE_BTC;
+    let (balance_alice, balance_bob) = generate_balances(fund_amount_alice, fund_amount_bob);
+
+    let time_lock = 1;
+
+    let (alice_wallet, bob_wallet) = runtime
+        .block_on(make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob))
+        .unwrap();
+    let (mut alice_transport, mut bob_transport) = make_transports();
+
+    let alice_create = Channel::create(
+        &mut alice_transport,
+        &alice_wallet,
+        balance_alice,
+        time_lock,
+    );
+    let bob_create = Channel::create(&mut bob_transport, &bob_wallet, balance_bob, time_lock);
+
+    let (mut alice_channel, mut bob_channel) = runtime
+        .block_on(futures::future::try_join(alice_create, bob_create))
+        .unwrap();
+
+    let after_open_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
+    let after_open_balance_bob = runtime.block_on(bob_wallet.0.balance()).unwrap();
+
+    let secret = PtlcSecret::new_random();
+    let point = secret.point();
+    let ptlc_amount = Amount::from_btc(0.5).unwrap();
+
+    let (alpha_absolute_expiry, TX_s_time_lock, ptlc_redeem_time_lock) = (1_598_875_222, 1, 1);
+
+    let swap_beta_ptlc_alice = alice_channel.swap_beta_ptlc_alice(
+        &mut alice_transport,
+        &alice_wallet,
+        ptlc_amount,
+        secret,
+        alpha_absolute_expiry,
+        TX_s_time_lock,
+        ptlc_redeem_time_lock,
+    );
+
+    let skip_final_update = false;
+    let swap_beta_ptlc_bob_with_final_update = swap_beta_ptlc_bob(
+        &mut bob_channel,
+        &mut bob_transport,
+        ptlc_amount,
+        point,
+        alpha_absolute_expiry,
+        TX_s_time_lock,
+        ptlc_redeem_time_lock,
+        skip_final_update,
+    );
+
+    runtime
+        .block_on(futures::future::try_join(
+            swap_beta_ptlc_alice,
+            swap_beta_ptlc_bob_with_final_update,
+        ))
+        .unwrap();
+
+    runtime
+        .block_on(alice_channel.force_close(&alice_wallet))
+        .unwrap();
+
+    let after_close_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
+    let after_close_balance_bob = runtime.block_on(bob_wallet.0.balance()).unwrap();
+
+    // We pay half a `thor::TX_FEE` per output in fees for each transaction after
+    // the `FundingTransaction`. Force closing the channel requires
+    // publishing two transactions: a `CommitTransaction` and a `SplitTransaction`,
+    // so each party pays a full `thor::TX_FEE`, which is deducted from their
+    // output.
+    let fee_deduction_per_output = Amount::from_sat(thor::TX_FEE);
+
+    assert_eq!(
+        after_close_balance_alice,
+        after_open_balance_alice + fund_amount_alice + ptlc_amount - fee_deduction_per_output,
+        "Balance after closing channel should equal balance after opening plus PTLC amount, minus transaction fees"
+    );
+    assert_eq!(
+        after_close_balance_bob,
+        after_open_balance_bob + fund_amount_bob - ptlc_amount - fee_deduction_per_output,
+        "Balance after closing channel should equal balance after opening minus PTLC amount, minus transaction fees"
+    );
+}
+
+#[test]
+fn e2e_atomic_swap_unresponsive_bob_after_secret_reveal() {
+    let mut runtime = build_runtime();
+
+    let tc_client = testcontainers::clients::Cli::default();
+    let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
+    runtime.block_on(bitcoind.init(5)).unwrap();
+
+    let fund_amount_alice = Amount::ONE_BTC;
+    let fund_amount_bob = Amount::ONE_BTC;
+    let (balance_alice, balance_bob) = generate_balances(fund_amount_alice, fund_amount_bob);
+
+    let time_lock = 1;
+
+    let (alice_wallet, bob_wallet) = runtime
+        .block_on(make_wallets(&bitcoind, fund_amount_alice, fund_amount_bob))
+        .unwrap();
+    let (mut alice_transport, mut bob_transport) = make_transports();
+
+    let alice_create = Channel::create(
+        &mut alice_transport,
+        &alice_wallet,
+        balance_alice,
+        time_lock,
+    );
+    let bob_create = Channel::create(&mut bob_transport, &bob_wallet, balance_bob, time_lock);
+
+    let (mut alice_channel, mut bob_channel) = runtime
+        .block_on(futures::future::try_join(alice_create, bob_create))
+        .unwrap();
+
+    let after_open_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
+    let after_open_balance_bob = runtime.block_on(bob_wallet.0.balance()).unwrap();
+
+    let secret = PtlcSecret::new_random();
+    let point = secret.point();
+    let ptlc_amount = Amount::from_btc(0.5).unwrap();
+
+    // TODO: produce redeem and refund transactions + fund alpha
+
+    let (alpha_absolute_expiry, TX_s_time_lock, ptlc_redeem_time_lock) = (1_598_875_222, 1, 1);
+
+    let swap_beta_ptlc_alice = alice_channel.swap_beta_ptlc_alice(
+        &mut alice_transport,
+        &alice_wallet,
+        ptlc_amount,
+        secret,
+        alpha_absolute_expiry,
+        TX_s_time_lock,
+        ptlc_redeem_time_lock,
+    );
+
+    let skip_final_update = true;
+    let swap_beta_ptlc_bob_without_final_update = swap_beta_ptlc_bob(
+        &mut bob_channel,
+        &mut bob_transport,
+        ptlc_amount,
+        point,
+        alpha_absolute_expiry,
+        TX_s_time_lock,
+        ptlc_redeem_time_lock,
+        skip_final_update,
+    );
+
+    runtime
+        .block_on(futures::future::try_join(
+            swap_beta_ptlc_alice,
+            swap_beta_ptlc_bob_without_final_update,
+        ))
+        .unwrap();
+
+    let after_close_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
+    let after_close_balance_bob = runtime.block_on(bob_wallet.0.balance()).unwrap();
+
+    // A `SplitTransaction` containing a PTLC output has 2 balance outputs and 1
+    // PTLC output, for a total of 3
+    let n_outputs_split_transaction = 3;
+
+    // We pay half a `thor::TX_FEE` per output in fees for each transaction after
+    // the `FundingTransaction`. Force closing the channel requires
+    // publishing two transactions: a `CommitTransaction` and a `SplitTransaction`,
+    // The fees are distributed evenly between the outputs.
+    let fee_deduction_per_split_output =
+        Amount::from_sat(thor::TX_FEE + thor::TX_FEE) / n_outputs_split_transaction;
+
+    // Alice will claim her balance output and a PTLC output
+    let split_transaction_fee_alice = fee_deduction_per_split_output * 2;
+
+    // Bob will just claim his balance output
+    let split_transaction_fee_bob = fee_deduction_per_split_output;
+
+    // Additionally, Alice pays an extra `thor::TX_FEE` to be able to redeem the
+    // PTLC output.
+    let fee_deduction_for_ptlc_redeem = Amount::from_sat(thor::TX_FEE);
+
+    assert_eq!(
+        after_close_balance_alice,
+        after_open_balance_alice + fund_amount_alice + ptlc_amount
+            - split_transaction_fee_alice - fee_deduction_for_ptlc_redeem,
+        "Balance after closing channel should equal balance after opening plus PTLC amount, minus transaction fees"
+    );
+    assert_eq!(
+        after_close_balance_bob,
+        after_open_balance_bob + fund_amount_bob - ptlc_amount - split_transaction_fee_bob,
+        "Balance after closing channel should equal balance after opening minus PTLC amount, minus transaction fees"
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn swap_beta_ptlc_bob(
+    channel: &mut Channel,
+    bob_transport: &mut Transport,
+    ptlc_amount: Amount,
+    point: PtlcPoint,
+    alpha_absolute_expiry: u32,
+    TX_s_time_lock: u32,
+    ptlc_redeem_time_lock: u32,
+    skip_update: bool,
+) -> anyhow::Result<()> {
+    let mut swap_beta_ptlc_bob = channel.swap_beta_ptlc_bob(
+        bob_transport,
+        ptlc_amount,
+        point,
+        alpha_absolute_expiry,
+        TX_s_time_lock,
+        ptlc_redeem_time_lock,
+    );
+
+    match swap_beta_ptlc_bob.async_resume().await {
+        GeneratorState::Yielded(_secret) => {
+            // TODO: Redeem alpha asset
+
+            if skip_update {
+                return Ok(());
+            }
+
+            match swap_beta_ptlc_bob.async_resume().await {
+                GeneratorState::Complete(Ok(())) => (),
+                GeneratorState::Complete(Err(e)) => panic!("{}", e),
+                GeneratorState::Yielded(_) => panic!("unexpected yield"),
+            }
+        }
+        GeneratorState::Complete(Err(e)) => panic!("{}", e),
+        GeneratorState::Complete(Ok(())) => panic!("did not yield secret"),
+    }
+
+    Ok(())
 }

--- a/thor/tests/harness/mod.rs
+++ b/thor/tests/harness/mod.rs
@@ -1,5 +1,31 @@
+use bitcoin::Amount;
+use thor::Balance;
+
 mod transport;
 mod wallet;
 
-pub use transport::make_transports;
+pub use transport::{make_transports, Transport};
 pub use wallet::make_wallets;
+
+pub fn build_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new()
+        .enable_all()
+        .threaded_scheduler()
+        .thread_stack_size(1024 * 1024 * 8)
+        .build()
+        .unwrap()
+}
+
+pub fn generate_balances(fund_amount_alice: Amount, fund_amount_bob: Amount) -> (Balance, Balance) {
+    let balance_alice = Balance {
+        ours: fund_amount_alice,
+        theirs: fund_amount_bob,
+    };
+
+    let balance_bob = Balance {
+        ours: fund_amount_bob,
+        theirs: fund_amount_alice,
+    };
+
+    (balance_alice, balance_bob)
+}


### PR DESCRIPTION
It's a little rough, but it works*. The alpha ledger is missing, but it's trivial since we're just gonna manually fund and redeem.

*On my machine all e2e tests started failing with stack overflows. I haven't been able to solve the problem outright, but I managed to mitigate it by running the tests with a `--release` flag and using a specific `runtime` to run the futures (as opposed to annotating tests with `#[tokio::test]`.

Despite these strange errors I don't think there's anything inherently wrong with the implementation. It could be `miniscript-rs` or `enum-as-inner`, but I need help investigating the issue. 

~I suspect the tests will fail on CI~ The tests are failing on CI for the same reason. Interestingly, the tests were passing with a `--release` flag on commit 2dd1d6e on my machine. The more code I add the more likely it is that any test will start failing again with a stack overflow :man_shrugging: 