### PR TITLE
Do some tidying

### DIFF
--- a/thor/src/keys.rs
+++ b/thor/src/keys.rs
@@ -1,3 +1,4 @@
+use ::serde::{Deserialize, Serialize};
 #[cfg(test)]
 use anyhow::anyhow;
 use anyhow::{bail, Result};
@@ -11,14 +12,14 @@ use ecdsa_fun::{
 use sha2::Sha256;
 use std::fmt;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct OwnershipKeyPair {
     secret_key: Scalar,
     public_key: Point,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct OwnershipPublicKey(Point);
 
@@ -76,18 +77,18 @@ impl From<Scalar> for OwnershipKeyPair {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct RevocationKeyPair {
     secret_key: Scalar,
     public_key: Point,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct RevocationSecretKey(Scalar);
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct RevocationPublicKey(Point);
 
@@ -154,7 +155,7 @@ impl From<RevocationSecretKey> for RevocationKeyPair {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct PublishingKeyPair {
     secret_key: Scalar,
@@ -164,7 +165,7 @@ pub struct PublishingKeyPair {
 #[derive(Clone, Debug)]
 pub struct PublishingSecretKey(Scalar);
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct PublishingPublicKey(Point);
 
@@ -240,7 +241,7 @@ impl fmt::Display for PublishingPublicKey {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct PtlcSecret(Scalar);
 
@@ -256,7 +257,7 @@ impl PtlcSecret {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PtlcPoint(Point);
 

--- a/thor/src/keys.rs
+++ b/thor/src/keys.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use anyhow::anyhow;
 use anyhow::{bail, Result};
 use bitcoin::{hashes::Hash, SigHash};
 use ecdsa_fun::{
@@ -314,8 +316,7 @@ pub fn point_from_str(from: &str) -> Result<Point> {
     let mut bytes = [0u8; 33];
     bytes.copy_from_slice(point.as_slice());
 
-    let point =
-        Point::from_bytes(bytes).ok_or_else(|| anyhow::anyhow!("string slice is not a Point"))?;
+    let point = Point::from_bytes(bytes).ok_or_else(|| anyhow!("string slice is not a Point"))?;
 
     Ok(point)
 }

--- a/thor/src/keys.rs
+++ b/thor/src/keys.rs
@@ -1,4 +1,4 @@
-use anyhow::bail;
+use anyhow::{bail, Result};
 use bitcoin::{hashes::Hash, SigHash};
 use ecdsa_fun::{
     adaptor::{Adaptor, EncryptedSignature},
@@ -113,10 +113,7 @@ impl RevocationKeyPair {
 pub struct WrongRevocationSecretKey;
 
 impl RevocationPublicKey {
-    pub fn verify_revocation_secret_key(
-        &self,
-        secret_key: &RevocationSecretKey,
-    ) -> anyhow::Result<()> {
+    pub fn verify_revocation_secret_key(&self, secret_key: &RevocationSecretKey) -> Result<()> {
         if self.0 != public_key(&secret_key.0) {
             bail!(WrongRevocationSecretKey)
         }
@@ -311,7 +308,7 @@ fn sign(secret_key: &Scalar, digest: SigHash) -> Signature {
 }
 
 #[cfg(test)]
-pub fn point_from_str(from: &str) -> anyhow::Result<Point> {
+pub fn point_from_str(from: &str) -> Result<Point> {
     let point = hex::decode(from)?;
 
     let mut bytes = [0u8; 33];

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -34,6 +34,7 @@ use crate::{
     protocols::punish::punish,
     transaction::{CommitTransaction, FundingTransaction, SplitTransaction},
 };
+use ::serde::{Deserialize, Serialize};
 use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 use bitcoin::{Address, Amount, Transaction, Txid};
@@ -50,7 +51,7 @@ use transaction::ptlc;
 /// Flat fee used for all transactions involved in the protocol, in satoshi.
 pub const TX_FEE: u64 = 10_000;
 
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct Channel {
     x_self: OwnershipKeyPair,
@@ -628,7 +629,7 @@ impl Channel {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, EnumAsInner)]
 pub(crate) enum ChannelState {
     Standard(StandardChannelState),
@@ -660,7 +661,7 @@ impl AsRef<StandardChannelState> for ChannelState {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct StandardChannelState {
     /// Proportion of the coins in the channel that currently belong to either
@@ -710,7 +711,7 @@ impl StandardChannelState {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub(crate) struct RevokedState {
     channel_state: ChannelState,
@@ -732,7 +733,7 @@ impl RevokedState {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Balance {
     #[cfg_attr(
@@ -747,7 +748,7 @@ pub struct Balance {
     pub theirs: Amount,
 }
 
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub enum SplitOutput {
     Ptlc(Ptlc),
@@ -761,7 +762,7 @@ pub enum SplitOutput {
     },
 }
 
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct Ptlc {
     #[cfg_attr(
@@ -785,7 +786,7 @@ impl Ptlc {
 }
 
 /// Role in an atomic swap.
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, EnumAsInner)]
 pub enum Role {
     Alice { secret: PtlcSecret },
@@ -803,7 +804,7 @@ impl SplitOutput {
 
 /// All possible messages that can be sent between two parties using this
 /// library.
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, EnumAsInner)]
 pub enum Message {
     Create0(create::Message0),

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -34,7 +34,7 @@ use crate::{
     protocols::punish::punish,
     transaction::{CommitTransaction, FundingTransaction, SplitTransaction},
 };
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use bitcoin::{Address, Amount, Transaction, Txid};
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
 use enum_as_inner::EnumAsInner;
@@ -201,7 +201,7 @@ impl Channel {
         let Balance { ours, theirs } = self.balance();
 
         let theirs = theirs.checked_sub(ptlc_amount).ok_or_else(|| {
-            anyhow::anyhow!(
+            anyhow!(
                 "Bob's {} balance cannot cover PTLC output amount: {}",
                 theirs,
                 ptlc_amount
@@ -315,7 +315,7 @@ impl Channel {
             let Balance { ours, theirs } = self.balance();
 
             let ours = ours.checked_sub(ptlc_amount).ok_or_else(|| {
-                anyhow::anyhow!(
+                anyhow!(
                     "Bob's {} balance cannot cover PTLC output amount: {}",
                     ours,
                     ptlc_amount

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -675,7 +675,7 @@ pub struct StandardChannelState {
     balance: Balance,
     TX_c: CommitTransaction,
     /// Encrypted signature received from the counterparty. It can be decrypted
-    /// using our `PublishingSecretkey` and used to sign `TX_c`. Keep in mind,
+    /// using our `PublishingSecretKey` and used to sign `TX_c`. Keep in mind,
     /// that publishing a revoked `TX_c` will allow the counterparty to punish
     /// us.
     encsig_TX_c_other: EncryptedSignature,
@@ -725,7 +725,7 @@ pub(crate) struct RevokedState {
 impl RevokedState {
     /// Add signatures to the `CommitTransaction`. Publishing the resulting
     /// transaction is punishable by the counterparty, as they can recover the
-    /// `PublishingSecretkey` from it and they already know the
+    /// `PublishingSecretKey` from it and they already know the
     /// `RevocationSecretKey`, since this state has already been revoked.
     pub fn signed_TX_c(
         &self,

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -500,6 +500,7 @@ impl Channel {
         Ok(())
     }
 
+    /// Close the channel non-collaboratively.
     pub async fn force_close<W>(&self, wallet: &W) -> Result<()>
     where
         W: NewAddress + BroadcastSignedTransaction,

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -543,6 +543,7 @@ impl Channel {
         Ok(())
     }
 
+    /// Get the current channel balance.
     pub fn balance(&self) -> Balance {
         let channel_state: &StandardChannelState = self.current_state.as_ref();
         channel_state.balance

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -31,7 +31,8 @@ use crate::{
         OwnershipKeyPair, OwnershipPublicKey, PublishingKeyPair, PublishingPublicKey,
         RevocationKeyPair, RevocationPublicKey, RevocationSecretKey,
     },
-    protocols::punish::punish,
+    protocols::{close, create, punish::punish, splice, update},
+    signature::decrypt,
     transaction::{
         CommitTransaction, FundingTransaction, RedeemTransaction, RefundTransaction,
         SplitTransaction,
@@ -45,8 +46,6 @@ use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
 use enum_as_inner::EnumAsInner;
 use futures::{future::Either, pin_mut, Future};
 use genawaiter::sync::Gen;
-use protocols::{close, create, splice, update};
-use signature::decrypt;
 
 // TODO: We should handle fees dynamically
 

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -726,7 +726,7 @@ impl RevokedState {
     pub fn signed_TX_c(
         &self,
         TX_f: &FundingTransaction,
-        x_self: keys::OwnershipKeyPair,
+        x_self: OwnershipKeyPair,
         X_other: OwnershipPublicKey,
     ) -> Result<Transaction> {
         StandardChannelState::from(self.channel_state.clone()).signed_TX_c(TX_f, &x_self, &X_other)

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -833,12 +833,12 @@ pub enum Message {
 
 #[derive(Debug, thiserror::Error)]
 #[error("expected message of type {expected_type}, got {received:?}")]
-pub struct UnexpecteMessage {
+pub struct UnexpectedMessage {
     expected_type: String,
     received: Message,
 }
 
-impl UnexpecteMessage {
+impl UnexpectedMessage {
     pub fn new<T>(received: Message) -> Self {
         let expected_type = std::any::type_name::<T>();
 
@@ -849,6 +849,6 @@ impl UnexpecteMessage {
     }
 }
 
-fn map_err<T>(res: Result<T, Message>) -> Result<T, UnexpecteMessage> {
-    res.map_err(UnexpecteMessage::new::<T>)
+fn map_err<T>(res: Result<T, Message>) -> Result<T, UnexpectedMessage> {
+    res.map_err(UnexpectedMessage::new::<T>)
 }

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -35,6 +35,7 @@ use crate::{
     transaction::{CommitTransaction, FundingTransaction, SplitTransaction},
 };
 use anyhow::{anyhow, bail, Result};
+use async_trait::async_trait;
 use bitcoin::{Address, Amount, Transaction, Txid};
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
 use enum_as_inner::EnumAsInner;
@@ -61,22 +62,22 @@ pub struct Channel {
     revoked_states: Vec<RevokedState>,
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 pub trait NewAddress {
     async fn new_address(&self) -> Result<Address>;
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 pub trait BroadcastSignedTransaction {
     async fn broadcast_signed_transaction(&self, transaction: Transaction) -> Result<()>;
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 pub trait SendMessage {
     async fn send_message(&mut self, message: Message) -> Result<()>;
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 pub trait ReceiveMessage {
     async fn receive_message(&mut self) -> Result<Message>;
 }

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -549,6 +549,7 @@ impl Channel {
         channel_state.balance
     }
 
+    /// Get the transaction id of the initial fund transaction.
     pub fn TX_f_txid(&self) -> Txid {
         self.TX_f_body.txid()
     }

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -32,7 +32,10 @@ use crate::{
         RevocationKeyPair, RevocationPublicKey, RevocationSecretKey,
     },
     protocols::punish::punish,
-    transaction::{CommitTransaction, FundingTransaction, SplitTransaction},
+    transaction::{
+        CommitTransaction, FundingTransaction, RedeemTransaction, RefundTransaction,
+        SplitTransaction,
+    },
 };
 use ::serde::{Deserialize, Serialize};
 use anyhow::{anyhow, bail, Result};
@@ -44,7 +47,6 @@ use futures::{future::Either, pin_mut, Future};
 use genawaiter::sync::Gen;
 use protocols::{close, create, splice, update};
 use signature::decrypt;
-use transaction::ptlc;
 
 // TODO: We should handle fees dynamically
 
@@ -636,8 +638,8 @@ pub(crate) enum ChannelState {
     WithPtlc {
         inner: StandardChannelState,
         ptlc: Ptlc,
-        TX_ptlc_redeem: ptlc::RedeemTransaction,
-        TX_ptlc_refund: ptlc::RefundTransaction,
+        TX_ptlc_redeem: RedeemTransaction,
+        TX_ptlc_refund: RefundTransaction,
         encsig_TX_ptlc_redeem_funder: EncryptedSignature,
         sig_TX_ptlc_redeem_redeemer: Signature,
         sig_TX_ptlc_refund_funder: Signature,

--- a/thor/src/protocols/close.rs
+++ b/thor/src/protocols/close.rs
@@ -3,7 +3,7 @@ use crate::{
     transaction::{CloseTransaction, FundingTransaction},
     Balance, Channel,
 };
-use anyhow::Context;
+use anyhow::{Context, Result};
 use bitcoin::{Address, Transaction};
 use ecdsa_fun::Signature;
 
@@ -35,7 +35,7 @@ impl State0 {
         }
     }
 
-    pub(crate) fn compose(&self) -> anyhow::Result<Message0> {
+    pub(crate) fn compose(&self) -> Result<Message0> {
         let close_transaction = CloseTransaction::new(&self.TX_f, [
             (self.balance.ours, self.final_address_self.clone()),
             (self.balance.theirs, self.final_address_other.clone()),
@@ -52,7 +52,7 @@ impl State0 {
         Message0 {
             sig_close_transaction: sig_close_transaction_other,
         }: Message0,
-    ) -> anyhow::Result<Transaction> {
+    ) -> Result<Transaction> {
         let close_transaction = CloseTransaction::new(&self.TX_f, [
             (self.balance.ours, self.final_address_self),
             (self.balance.theirs, self.final_address_other),

--- a/thor/src/protocols/close.rs
+++ b/thor/src/protocols/close.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 pub(crate) struct State0 {
     x_self: OwnershipKeyPair,
     X_other: OwnershipPublicKey,
-    TX_f: FundingTransaction,
+    tx_f: FundingTransaction,
     final_address_self: Address,
     final_address_other: Address,
     balance: Balance,
@@ -29,7 +29,7 @@ impl State0 {
         Self {
             x_self: channel.x_self.clone(),
             X_other: channel.X_other.clone(),
-            TX_f: channel.TX_f_body.clone(),
+            tx_f: channel.tx_f_body.clone(),
             balance: channel.balance(),
             final_address_self: channel.final_address_self.clone(),
             final_address_other: channel.final_address_other.clone(),
@@ -37,7 +37,7 @@ impl State0 {
     }
 
     pub(crate) fn compose(&self) -> Result<Message0> {
-        let close_transaction = CloseTransaction::new(&self.TX_f, [
+        let close_transaction = CloseTransaction::new(&self.tx_f, [
             (self.balance.ours, self.final_address_self.clone()),
             (self.balance.theirs, self.final_address_other.clone()),
         ])?;
@@ -54,7 +54,7 @@ impl State0 {
             sig_close_transaction: sig_close_transaction_other,
         }: Message0,
     ) -> Result<Transaction> {
-        let close_transaction = CloseTransaction::new(&self.TX_f, [
+        let close_transaction = CloseTransaction::new(&self.tx_f, [
             (self.balance.ours, self.final_address_self),
             (self.balance.theirs, self.final_address_other),
         ])?;

--- a/thor/src/protocols/close.rs
+++ b/thor/src/protocols/close.rs
@@ -6,6 +6,7 @@ use crate::{
 use anyhow::{Context, Result};
 use bitcoin::{Address, Transaction};
 use ecdsa_fun::Signature;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 pub(crate) struct State0 {
@@ -17,7 +18,7 @@ pub(crate) struct State0 {
     balance: Balance,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message0 {
     sig_close_transaction: Signature,

--- a/thor/src/protocols/create.rs
+++ b/thor/src/protocols/create.rs
@@ -39,13 +39,13 @@ pub struct Message2 {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message3 {
-    sig_TX_s: Signature,
+    sig_tx_s: Signature,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message4 {
-    encsig_TX_c: EncryptedSignature,
+    encsig_tx_c: EncryptedSignature,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -55,7 +55,7 @@ pub struct Message5 {
         feature = "serde",
         serde(with = "crate::serde::partially_signed_transaction")
     )]
-    TX_f_signed_once: PartiallySignedTransaction,
+    tx_f_signed_once: PartiallySignedTransaction,
 }
 
 #[derive(Debug)]
@@ -143,7 +143,7 @@ impl State1 {
             input_psbt: input_pstb_other,
         }: Message1,
     ) -> Result<State2> {
-        let TX_f = FundingTransaction::new(vec![self.input_psbt_self.clone(), input_pstb_other], [
+        let tx_f = FundingTransaction::new(vec![self.input_psbt_self.clone(), input_pstb_other], [
             (self.x_self.public(), self.balance.ours),
             (self.X_other.clone(), self.balance.theirs),
         ])
@@ -161,7 +161,7 @@ impl State1 {
             time_lock: self.time_lock,
             r_self: r,
             y_self: y,
-            TX_f,
+            tx_f,
         })
     }
 }
@@ -176,7 +176,7 @@ pub(crate) struct State2 {
     time_lock: u32,
     r_self: RevocationKeyPair,
     y_self: PublishingKeyPair,
-    TX_f: FundingTransaction,
+    tx_f: FundingTransaction,
 }
 
 impl State2 {
@@ -194,8 +194,8 @@ impl State2 {
             Y: Y_other,
         }: Message2,
     ) -> Result<Party3> {
-        let TX_c = CommitTransaction::new(
-            &self.TX_f,
+        let tx_c = CommitTransaction::new(
+            &self.tx_f,
             [
                 (
                     self.x_self.public(),
@@ -217,8 +217,8 @@ impl State2 {
                 address: self.final_address_other.clone(),
             },
         ];
-        let TX_s = SplitTransaction::new(&TX_c, split_outputs.clone())?;
-        let sig_TX_s_self = TX_s.sign_once(&self.x_self);
+        let tx_s = SplitTransaction::new(&tx_c, split_outputs.clone())?;
+        let sig_tx_s_self = tx_s.sign_once(&self.x_self);
 
         Ok(Party3 {
             x_self: self.x_self,
@@ -230,10 +230,10 @@ impl State2 {
             R_other,
             y_self: self.y_self,
             Y_other,
-            TX_f: self.TX_f,
-            TX_c,
-            TX_s,
-            sig_TX_s_self,
+            tx_f: self.tx_f,
+            tx_c,
+            tx_s,
+            sig_tx_s_self,
         })
     }
 }
@@ -249,35 +249,35 @@ pub(crate) struct Party3 {
     R_other: RevocationPublicKey,
     y_self: PublishingKeyPair,
     Y_other: PublishingPublicKey,
-    TX_f: FundingTransaction,
-    TX_c: CommitTransaction,
-    TX_s: SplitTransaction,
-    sig_TX_s_self: Signature,
+    tx_f: FundingTransaction,
+    tx_c: CommitTransaction,
+    tx_s: SplitTransaction,
+    sig_tx_s_self: Signature,
 }
 
 impl Party3 {
     pub fn next_message(&self) -> Message3 {
         Message3 {
-            sig_TX_s: self.sig_TX_s_self.clone(),
+            sig_tx_s: self.sig_tx_s_self.clone(),
         }
     }
 
     pub fn receive(
         mut self,
         Message3 {
-            sig_TX_s: sig_TX_s_other,
+            sig_tx_s: sig_tx_s_other,
         }: Message3,
     ) -> Result<Party4> {
-        self.TX_s
-            .verify_sig(self.X_other.clone(), &sig_TX_s_other)
-            .context("failed to verify sig_TX_s sent by counterparty")?;
+        self.tx_s
+            .verify_sig(self.X_other.clone(), &sig_tx_s_other)
+            .context("failed to verify sig_tx_s sent by counterparty")?;
 
-        self.TX_s.add_signatures(
-            (self.x_self.public(), self.sig_TX_s_self),
-            (self.X_other.clone(), sig_TX_s_other),
+        self.tx_s.add_signatures(
+            (self.x_self.public(), self.sig_tx_s_self),
+            (self.X_other.clone(), sig_tx_s_other),
         )?;
 
-        let encsig_TX_c_self = self.TX_c.encsign_once(&self.x_self, self.Y_other.clone());
+        let encsig_tx_c_self = self.tx_c.encsign_once(&self.x_self, self.Y_other.clone());
 
         Ok(Party4 {
             x_self: self.x_self,
@@ -289,10 +289,10 @@ impl Party3 {
             R_other: self.R_other,
             y_self: self.y_self,
             Y_other: self.Y_other,
-            TX_f: self.TX_f,
-            TX_c: self.TX_c,
-            signed_TX_s: self.TX_s,
-            encsig_TX_c_self,
+            tx_f: self.tx_f,
+            tx_c: self.tx_c,
+            signed_tx_s: self.tx_s,
+            encsig_tx_c_self,
         })
     }
 }
@@ -308,32 +308,32 @@ pub(crate) struct Party4 {
     R_other: RevocationPublicKey,
     y_self: PublishingKeyPair,
     Y_other: PublishingPublicKey,
-    TX_f: FundingTransaction,
-    TX_c: CommitTransaction,
-    signed_TX_s: SplitTransaction,
-    encsig_TX_c_self: EncryptedSignature,
+    tx_f: FundingTransaction,
+    tx_c: CommitTransaction,
+    signed_tx_s: SplitTransaction,
+    encsig_tx_c_self: EncryptedSignature,
 }
 
 impl Party4 {
     pub fn next_message(&self) -> Message4 {
         Message4 {
-            encsig_TX_c: self.encsig_TX_c_self.clone(),
+            encsig_tx_c: self.encsig_tx_c_self.clone(),
         }
     }
 
     pub fn receive(
         self,
         Message4 {
-            encsig_TX_c: encsig_TX_c_other,
+            encsig_tx_c: encsig_tx_c_other,
         }: Message4,
     ) -> Result<Party5> {
-        self.TX_c
+        self.tx_c
             .verify_encsig(
                 self.X_other.clone(),
                 self.y_self.public(),
-                &encsig_TX_c_other,
+                &encsig_tx_c_other,
             )
-            .context("failed to verify encsig_TX_c sent by counterparty")?;
+            .context("failed to verify encsig_tx_c sent by counterparty")?;
 
         Ok(Party5 {
             x_self: self.x_self,
@@ -345,10 +345,10 @@ impl Party4 {
             R_other: self.R_other,
             y_self: self.y_self,
             Y_other: self.Y_other,
-            TX_f: self.TX_f,
-            TX_c: self.TX_c,
-            signed_TX_s: self.signed_TX_s,
-            encsig_TX_c_other,
+            tx_f: self.tx_f,
+            tx_c: self.tx_c,
+            signed_tx_s: self.signed_tx_s,
+            encsig_tx_c_other,
         })
     }
 }
@@ -364,10 +364,10 @@ pub(crate) struct Party5 {
     R_other: RevocationPublicKey,
     y_self: PublishingKeyPair,
     Y_other: PublishingPublicKey,
-    TX_f: FundingTransaction,
-    TX_c: CommitTransaction,
-    signed_TX_s: SplitTransaction,
-    encsig_TX_c_other: EncryptedSignature,
+    tx_f: FundingTransaction,
+    tx_c: CommitTransaction,
+    signed_tx_s: SplitTransaction,
+    encsig_tx_c_other: EncryptedSignature,
 }
 
 /// Sign one of the inputs of the `FundingTransaction`.
@@ -381,21 +381,21 @@ pub trait SignFundingPSBT {
 
 impl Party5 {
     pub async fn next_message(&self, wallet: &impl SignFundingPSBT) -> Result<Message5> {
-        let TX_f_signed_once = wallet
-            .sign_funding_psbt(self.TX_f.clone().into_psbt()?)
+        let tx_f_signed_once = wallet
+            .sign_funding_psbt(self.tx_f.clone().into_psbt()?)
             .await?;
 
-        Ok(Message5 { TX_f_signed_once })
+        Ok(Message5 { tx_f_signed_once })
     }
 
     /// Returns the Channel and the transaction to broadcast.
     pub async fn receive(
         self,
-        Message5 { TX_f_signed_once }: Message5,
+        Message5 { tx_f_signed_once }: Message5,
         wallet: &impl SignFundingPSBT,
     ) -> Result<(Channel, Transaction)> {
-        let signed_TX_f = wallet.sign_funding_psbt(TX_f_signed_once).await?;
-        let signed_TX_f = signed_TX_f.extract_tx();
+        let signed_tx_f = wallet.sign_funding_psbt(tx_f_signed_once).await?;
+        let signed_tx_f = signed_tx_f.extract_tx();
 
         Ok((
             Channel {
@@ -403,24 +403,24 @@ impl Party5 {
                 X_other: self.X_other,
                 final_address_self: self.final_address_self.clone(),
                 final_address_other: self.final_address_other.clone(),
-                TX_f_body: self.TX_f,
+                tx_f_body: self.tx_f,
                 current_state: ChannelState::Standard(StandardChannelState {
                     balance: balance(
                         self.split_outputs,
                         &self.final_address_self,
                         &self.final_address_other,
                     ),
-                    TX_c: self.TX_c,
-                    encsig_TX_c_other: self.encsig_TX_c_other,
+                    tx_c: self.tx_c,
+                    encsig_tx_c_other: self.encsig_tx_c_other,
                     r_self: self.r_self,
                     R_other: self.R_other,
                     y_self: self.y_self,
                     Y_other: self.Y_other,
-                    signed_TX_s: self.signed_TX_s,
+                    signed_tx_s: self.signed_tx_s,
                 }),
                 revoked_states: vec![],
             },
-            signed_TX_f,
+            signed_tx_f,
         ))
     }
 }

--- a/thor/src/protocols/create.rs
+++ b/thor/src/protocols/create.rs
@@ -10,15 +10,16 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount, Transaction};
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message0 {
     X: OwnershipPublicKey,
     final_address: Address,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message1 {
     #[cfg_attr(
@@ -28,26 +29,26 @@ pub struct Message1 {
     input_psbt: PartiallySignedTransaction,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message2 {
     R: RevocationPublicKey,
     Y: PublishingPublicKey,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message3 {
     sig_TX_s: Signature,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message4 {
     encsig_TX_c: EncryptedSignature,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message5 {
     #[cfg_attr(

--- a/thor/src/protocols/create.rs
+++ b/thor/src/protocols/create.rs
@@ -7,6 +7,7 @@ use crate::{
     Balance, Channel, ChannelState, SplitOutput, StandardChannelState,
 };
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount, Transaction};
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
 
@@ -64,7 +65,7 @@ pub(crate) struct State0 {
     time_lock: u32,
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 pub trait BuildFundingPSBT {
     async fn build_funding_psbt(
         &self,
@@ -369,7 +370,7 @@ pub(crate) struct Party5 {
 }
 
 /// Sign one of the inputs of the `FundingTransaction`.
-#[async_trait::async_trait]
+#[async_trait]
 pub trait SignFundingPSBT {
     async fn sign_funding_psbt(
         &self,

--- a/thor/src/protocols/punish.rs
+++ b/thor/src/protocols/punish.rs
@@ -1,6 +1,7 @@
 use crate::{
     keys::OwnershipKeyPair, transaction::PunishTransaction, RevokedState, StandardChannelState,
 };
+use anyhow::Result;
 use bitcoin::{Address, Transaction};
 
 #[derive(Copy, Clone, Debug, thiserror::Error)]
@@ -12,7 +13,7 @@ pub(crate) fn punish(
     revoked_states: &[RevokedState],
     final_address: Address,
     old_commit_transaction: Transaction,
-) -> anyhow::Result<PunishTransaction> {
+) -> Result<PunishTransaction> {
     let (channel_state, r_other) = revoked_states
         .iter()
         .map(|state| {

--- a/thor/src/protocols/punish.rs
+++ b/thor/src/protocols/punish.rs
@@ -22,22 +22,22 @@ pub(crate) fn punish(
                 state.r_other.clone(),
             )
         })
-        .find(|(state, _)| state.TX_c.txid() == old_commit_transaction.txid())
+        .find(|(state, _)| state.tx_c.txid() == old_commit_transaction.txid())
         .ok_or_else(|| NotOldCommitTransaction)?;
 
-    let encsig_TX_c_self = channel_state.encsign_TX_c_self(x_self);
+    let encsig_tx_c_self = channel_state.encsign_tx_c_self(x_self);
 
-    let StandardChannelState { TX_c, Y_other, .. } = channel_state;
+    let StandardChannelState { tx_c, Y_other, .. } = channel_state;
 
-    let TX_p = PunishTransaction::new(
+    let tx_p = PunishTransaction::new(
         x_self,
         final_address,
-        &TX_c,
-        &encsig_TX_c_self,
+        &tx_c,
+        &encsig_tx_c_self,
         &r_other.into(),
         Y_other,
         old_commit_transaction,
     )?;
 
-    Ok(TX_p)
+    Ok(tx_p)
 }

--- a/thor/src/protocols/splice.rs
+++ b/thor/src/protocols/splice.rs
@@ -16,9 +16,10 @@ use bitcoin::{
 };
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
 use miniscript::Descriptor;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message0 {
     R: RevocationPublicKey,
@@ -27,19 +28,19 @@ pub struct Message0 {
     splice_in: Option<SpliceIn>,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message1 {
     sig_TX_s: Signature,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message2 {
     encsig_TX_c: EncryptedSignature,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message3 {
     splice_transaction_signature: Signature,
@@ -65,7 +66,7 @@ pub(crate) struct State0 {
     splice_in_self: Option<SpliceIn>,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct SpliceIn {
     #[cfg_attr(

--- a/thor/src/protocols/splice.rs
+++ b/thor/src/protocols/splice.rs
@@ -10,6 +10,7 @@ use crate::{
     StandardChannelState,
 };
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use bitcoin::{
     consensus::serialize, util::psbt::PartiallySignedTransaction, Address, Amount, Transaction,
 };
@@ -79,7 +80,7 @@ pub struct SpliceIn {
     pub input_psbt: PartiallySignedTransaction,
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 pub trait BuildSplicePSBT {
     async fn build_funding_psbt(
         &self,

--- a/thor/src/protocols/splice.rs
+++ b/thor/src/protocols/splice.rs
@@ -31,13 +31,13 @@ pub struct Message0 {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message1 {
-    sig_TX_s: Signature,
+    sig_tx_s: Signature,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Message2 {
-    encsig_TX_c: EncryptedSignature,
+    encsig_tx_c: EncryptedSignature,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -59,7 +59,7 @@ pub(crate) struct State0 {
     final_address_self: Address,
     final_address_other: Address,
     previous_balance: Balance,
-    previous_TX_f: FundingTransaction,
+    previous_tx_f: FundingTransaction,
     time_lock: u32,
     r_self: RevocationKeyPair,
     y_self: PublishingKeyPair,
@@ -97,7 +97,7 @@ impl State0 {
         final_address_self: Address,
         final_address_other: Address,
         previous_balance: Balance,
-        previous_TX_f: FundingTransaction,
+        previous_tx_f: FundingTransaction,
         x_self: OwnershipKeyPair,
         X_other: OwnershipPublicKey,
         splice_in: Option<Amount>,
@@ -126,7 +126,7 @@ impl State0 {
             final_address_self,
             final_address_other,
             previous_balance,
-            previous_TX_f,
+            previous_tx_f,
             r_self: r,
             y_self: y,
             splice_in_self,
@@ -150,7 +150,7 @@ impl State0 {
             splice_in: splice_in_other,
         }: Message0,
     ) -> Result<State1> {
-        let previous_funding_txin = self.previous_TX_f.as_txin();
+        let previous_funding_txin = self.previous_tx_f.as_txin();
         let previous_funding_psbt = PartiallySignedTransaction::from_unsigned_tx(Transaction {
             version: 2,
             lock_time: 0,
@@ -193,18 +193,18 @@ impl State0 {
             theirs: their_balance,
         };
 
-        let TX_f = SpliceTransaction::new(inputs, [
+        let tx_f = SpliceTransaction::new(inputs, [
             (self.x_self.public(), balance.ours),
             (self.X_other.clone(), balance.theirs),
         ])?;
 
         // TODO: Clean-up the signature/PSBT mix (if possible)
 
-        // Signed to spend TX_f
-        let sig_TX_f = TX_f.sign_once(self.x_self.clone(), &self.previous_TX_f);
+        // Signed to spend tx_f
+        let sig_tx_f = tx_f.sign_once(self.x_self.clone(), &self.previous_tx_f);
 
-        let TX_c = CommitTransaction::new(
-            &TX_f.clone().into(),
+        let tx_c = CommitTransaction::new(
+            &tx_f.clone().into(),
             [
                 (
                     self.x_self.public(),
@@ -215,9 +215,9 @@ impl State0 {
             ],
             self.time_lock,
         )?;
-        let encsig_TX_c_self = TX_c.encsign_once(&self.x_self, Y_other.clone());
+        let encsig_tx_c_self = tx_c.encsign_once(&self.x_self, Y_other.clone());
 
-        let TX_s = SplitTransaction::new(&TX_c, vec![
+        let tx_s = SplitTransaction::new(&tx_c, vec![
             SplitOutput::Balance {
                 amount: balance.ours,
                 address: self.final_address_self.clone(),
@@ -227,7 +227,7 @@ impl State0 {
                 address: self.final_address_other.clone(),
             },
         ])?;
-        let sig_TX_s_self = TX_s.sign_once(&self.x_self);
+        let sig_tx_s_self = tx_s.sign_once(&self.x_self);
 
         Ok(State1 {
             x_self: self.x_self,
@@ -239,13 +239,13 @@ impl State0 {
             R_other,
             y_self: self.y_self,
             Y_other,
-            previous_TX_f_output_descriptor: self.previous_TX_f.fund_output_descriptor(),
-            splice_transaction: TX_f,
-            splice_transaction_signature: sig_TX_f,
-            TX_c,
-            TX_s,
-            encsig_TX_c_self,
-            sig_TX_s_self,
+            previous_tx_f_output_descriptor: self.previous_tx_f.fund_output_descriptor(),
+            splice_transaction: tx_f,
+            splice_transaction_signature: sig_tx_f,
+            tx_c,
+            tx_s,
+            encsig_tx_c_self,
+            sig_tx_s_self,
             splice_in_self: self.splice_in_self,
         })
     }
@@ -262,36 +262,36 @@ pub(crate) struct State1 {
     R_other: RevocationPublicKey,
     y_self: PublishingKeyPair,
     Y_other: PublishingPublicKey,
-    previous_TX_f_output_descriptor: Descriptor<bitcoin::PublicKey>,
+    previous_tx_f_output_descriptor: Descriptor<bitcoin::PublicKey>,
     splice_transaction: SpliceTransaction,
     splice_transaction_signature: Signature,
-    TX_c: CommitTransaction,
-    TX_s: SplitTransaction,
-    encsig_TX_c_self: EncryptedSignature,
-    sig_TX_s_self: Signature,
+    tx_c: CommitTransaction,
+    tx_s: SplitTransaction,
+    encsig_tx_c_self: EncryptedSignature,
+    sig_tx_s_self: Signature,
     splice_in_self: Option<SpliceIn>,
 }
 
 impl State1 {
     pub fn next_message(&self) -> Message1 {
         Message1 {
-            sig_TX_s: self.sig_TX_s_self.clone(),
+            sig_tx_s: self.sig_tx_s_self.clone(),
         }
     }
 
     pub fn receive(
         mut self,
         Message1 {
-            sig_TX_s: sig_TX_s_other,
+            sig_tx_s: sig_tx_s_other,
         }: Message1,
     ) -> Result<State2> {
-        self.TX_s
-            .verify_sig(self.X_other.clone(), &sig_TX_s_other)
-            .context("failed to verify sig_TX_s sent by counterparty")?;
+        self.tx_s
+            .verify_sig(self.X_other.clone(), &sig_tx_s_other)
+            .context("failed to verify sig_tx_s sent by counterparty")?;
 
-        self.TX_s.add_signatures(
-            (self.x_self.public(), self.sig_TX_s_self),
-            (self.X_other.clone(), sig_TX_s_other),
+        self.tx_s.add_signatures(
+            (self.x_self.public(), self.sig_tx_s_self),
+            (self.X_other.clone(), sig_tx_s_other),
         )?;
 
         Ok(State2 {
@@ -304,12 +304,12 @@ impl State1 {
             R_other: self.R_other,
             y_self: self.y_self,
             Y_other: self.Y_other,
-            previous_TX_f_output_descriptor: self.previous_TX_f_output_descriptor,
+            previous_tx_f_output_descriptor: self.previous_tx_f_output_descriptor,
             splice_transaction: self.splice_transaction,
             splice_transaction_signature: self.splice_transaction_signature,
-            TX_c: self.TX_c,
-            signed_TX_s: self.TX_s,
-            encsig_TX_c_self: self.encsig_TX_c_self,
+            tx_c: self.tx_c,
+            signed_tx_s: self.tx_s,
+            encsig_tx_c_self: self.encsig_tx_c_self,
             splice_in_self: self.splice_in_self,
         })
     }
@@ -326,36 +326,36 @@ pub(crate) struct State2 {
     R_other: RevocationPublicKey,
     y_self: PublishingKeyPair,
     Y_other: PublishingPublicKey,
-    previous_TX_f_output_descriptor: Descriptor<bitcoin::PublicKey>,
+    previous_tx_f_output_descriptor: Descriptor<bitcoin::PublicKey>,
     splice_transaction: SpliceTransaction,
     splice_transaction_signature: Signature,
-    TX_c: CommitTransaction,
-    signed_TX_s: SplitTransaction,
-    encsig_TX_c_self: EncryptedSignature,
+    tx_c: CommitTransaction,
+    signed_tx_s: SplitTransaction,
+    encsig_tx_c_self: EncryptedSignature,
     splice_in_self: Option<SpliceIn>,
 }
 
 impl State2 {
     pub fn next_message(&self) -> Message2 {
         Message2 {
-            encsig_TX_c: self.encsig_TX_c_self.clone(),
+            encsig_tx_c: self.encsig_tx_c_self.clone(),
         }
     }
 
     pub async fn receive(
         self,
         Message2 {
-            encsig_TX_c: encsig_TX_c_other,
+            encsig_tx_c: encsig_tx_c_other,
         }: Message2,
         wallet: &impl SignFundingPSBT,
     ) -> Result<State3> {
-        self.TX_c
+        self.tx_c
             .verify_encsig(
                 self.X_other.clone(),
                 self.y_self.public(),
-                &encsig_TX_c_other,
+                &encsig_tx_c_other,
             )
-            .context("failed to verify encsig_TX_c sent by counterparty")?;
+            .context("failed to verify encsig_tx_c sent by counterparty")?;
 
         // Signed to spend the splice-in input
         let signed_splice_transaction = match self.splice_in_self {
@@ -377,13 +377,13 @@ impl State2 {
             R_other: self.R_other,
             y_self: self.y_self,
             Y_other: self.Y_other,
-            previous_TX_f_output_descriptor: self.previous_TX_f_output_descriptor,
+            previous_tx_f_output_descriptor: self.previous_tx_f_output_descriptor,
             splice_transaction: self.splice_transaction,
             splice_transaction_signature: self.splice_transaction_signature,
-            TX_c: self.TX_c,
-            signed_TX_s: self.signed_TX_s,
-            encsig_TX_c_self: self.encsig_TX_c_self,
-            encsig_TX_c_other,
+            tx_c: self.tx_c,
+            signed_tx_s: self.signed_tx_s,
+            encsig_tx_c_self: self.encsig_tx_c_self,
+            encsig_tx_c_other,
             signed_splice_transaction,
         })
     }
@@ -400,13 +400,13 @@ pub(crate) struct State3 {
     R_other: RevocationPublicKey,
     y_self: PublishingKeyPair,
     Y_other: PublishingPublicKey,
-    previous_TX_f_output_descriptor: Descriptor<bitcoin::PublicKey>,
+    previous_tx_f_output_descriptor: Descriptor<bitcoin::PublicKey>,
     splice_transaction: SpliceTransaction,
     splice_transaction_signature: Signature,
-    TX_c: CommitTransaction,
-    signed_TX_s: SplitTransaction,
-    encsig_TX_c_self: EncryptedSignature,
-    encsig_TX_c_other: EncryptedSignature,
+    tx_c: CommitTransaction,
+    signed_tx_s: SplitTransaction,
+    encsig_tx_c_self: EncryptedSignature,
+    encsig_tx_c_other: EncryptedSignature,
     signed_splice_transaction: Option<PartiallySignedTransaction>,
 }
 
@@ -428,24 +428,24 @@ impl State3 {
         wallet: &impl SignFundingPSBT,
     ) -> Result<(Channel, Transaction)> {
         // TODO: Check that the received splice transaction is the same than we expect
-        // If the other party sent a splice-in signed TX_f, use it, otherwise, use our
-        // unsigned TX_f
+        // If the other party sent a splice-in signed tx_f, use it, otherwise, use our
+        // unsigned tx_f
         let splice_transaction = match signed_splice_transaction_other {
             Some(signed_splice_transaction_other) => signed_splice_transaction_other,
             None => self.splice_transaction.clone().into_psbt()?,
         };
 
         // If we have a splice-in input, we need to sign it, otherwise, use the previous
-        // TX_f
+        // tx_f
         let splice_transaction = match self.signed_splice_transaction {
             Some(_) => wallet.sign_funding_psbt(splice_transaction).await?,
             None => splice_transaction,
         };
 
-        // Add the signatures to spend the previous TX_f
+        // Add the signatures to spend the previous tx_f
         let splice_transaction = add_signatures(
             splice_transaction.extract_tx(),
-            self.previous_TX_f_output_descriptor,
+            self.previous_tx_f_output_descriptor,
             (self.x_self.public(), self.splice_transaction_signature),
             (self.X_other.clone(), splice_transaction_signature_other),
         )?;
@@ -456,16 +456,16 @@ impl State3 {
                 X_other: self.X_other,
                 final_address_self: self.final_address_self,
                 final_address_other: self.final_address_other,
-                TX_f_body: self.splice_transaction.into(),
+                tx_f_body: self.splice_transaction.into(),
                 current_state: ChannelState::Standard(StandardChannelState {
                     balance: self.balance,
-                    TX_c: self.TX_c,
-                    encsig_TX_c_other: self.encsig_TX_c_other,
+                    tx_c: self.tx_c,
+                    encsig_tx_c_other: self.encsig_tx_c_other,
                     r_self: self.r_self,
                     R_other: self.R_other,
                     y_self: self.y_self,
                     Y_other: self.Y_other,
-                    signed_TX_s: self.signed_TX_s,
+                    signed_tx_s: self.signed_tx_s,
                 }),
                 revoked_states: vec![],
             },

--- a/thor/src/protocols/update.rs
+++ b/thor/src/protocols/update.rs
@@ -9,9 +9,10 @@ use crate::{
 use anyhow::{bail, Context, Result};
 use bitcoin::Address;
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
+use serde::{Deserialize, Serialize};
 
 /// First message of the channel update protocol.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct ShareKeys {
     R: RevocationPublicKey,
@@ -19,21 +20,21 @@ pub struct ShareKeys {
 }
 
 /// Second message of the channel update protocol.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct ShareSplitSignature {
     sig_TX_s: Signature,
 }
 
 /// Third message of the channel update protocol.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct ShareCommitEncryptedSignature {
     encsig_TX_c: EncryptedSignature,
 }
 
 /// Fourth and last message of the channel update protocol.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct RevealRevocationSecretKey {
     r: RevocationSecretKey,
@@ -160,7 +161,7 @@ pub enum State1Kind {
 
 /// Message sent by the PTLC funder in a channel update protocol execution
 /// involving a PTLC output.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct SignaturesPtlcFunder {
     encsig_TX_ptlc_redeem_funder: EncryptedSignature,
@@ -169,7 +170,7 @@ pub struct SignaturesPtlcFunder {
 
 /// Message sent by the PTLC redeemer in a channel update protocol execution
 /// involving a PTLC output.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct SignaturesPtlcRedeemer {
     sig_TX_ptlc_redeem_redeemer: Signature,

--- a/thor/src/protocols/update.rs
+++ b/thor/src/protocols/update.rs
@@ -6,7 +6,7 @@ use crate::{
     transaction::{balance, ptlc, CommitTransaction, FundingTransaction, SplitTransaction},
     Channel, ChannelState, Ptlc, RevokedState, SplitOutput, StandardChannelState,
 };
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use bitcoin::Address;
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
 
@@ -139,7 +139,7 @@ impl State0 {
             Some(ptlc) if ptlc.X_redeemer == self.x_self.public() => Ok(
                 State1Kind::State1PtlcRedeemer(State1PtlcRedeemer::new(state, ptlc)?),
             ),
-            _ => anyhow::bail!("ownership of PTLC output is not shared by X_self"),
+            _ => bail!("ownership of PTLC output is not shared by X_self"),
         }
     }
 }

--- a/thor/src/protocols/update.rs
+++ b/thor/src/protocols/update.rs
@@ -26,14 +26,14 @@ pub struct ShareKeys {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct ShareSplitSignature {
-    sig_TX_s: Signature,
+    sig_tx_s: Signature,
 }
 
 /// Third message of the channel update protocol.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct ShareCommitEncryptedSignature {
-    encsig_TX_c: EncryptedSignature,
+    encsig_tx_c: EncryptedSignature,
 }
 
 /// Fourth and last message of the channel update protocol.
@@ -49,7 +49,7 @@ pub struct State0 {
     X_other: OwnershipPublicKey,
     final_address_self: Address,
     final_address_other: Address,
-    TX_f_body: FundingTransaction,
+    tx_f_body: FundingTransaction,
     current_state: ChannelState,
     revoked_states: Vec<RevokedState>,
     new_split_outputs: Vec<SplitOutput>,
@@ -68,7 +68,7 @@ impl State0 {
             X_other: channel.X_other,
             final_address_self: channel.final_address_self,
             final_address_other: channel.final_address_other,
-            TX_f_body: channel.TX_f_body,
+            tx_f_body: channel.tx_f_body,
             current_state: channel.current_state,
             revoked_states: channel.revoked_states,
             new_split_outputs,
@@ -92,8 +92,8 @@ impl State0 {
             Y: Y_other,
         }: ShareKeys,
     ) -> Result<State1Kind> {
-        let TX_c = CommitTransaction::new(
-            &self.TX_f_body,
+        let tx_c = CommitTransaction::new(
+            &self.tx_f_body,
             [
                 (
                     self.x_self.public(),
@@ -104,17 +104,17 @@ impl State0 {
             ],
             self.time_lock,
         )?;
-        let encsig_TX_c_self = TX_c.encsign_once(&self.x_self, Y_other.clone());
+        let encsig_tx_c_self = tx_c.encsign_once(&self.x_self, Y_other.clone());
 
-        let TX_s = SplitTransaction::new(&TX_c, self.new_split_outputs.clone())?;
-        let sig_TX_s_self = TX_s.sign_once(&self.x_self);
+        let tx_s = SplitTransaction::new(&tx_c, self.new_split_outputs.clone())?;
+        let sig_tx_s_self = tx_s.sign_once(&self.x_self);
 
         let state = State1 {
             x_self: self.x_self.clone(),
             X_other: self.X_other,
             final_address_self: self.final_address_self,
             final_address_other: self.final_address_other,
-            TX_f: self.TX_f_body,
+            tx_f: self.tx_f_body,
             current_state: self.current_state,
             revoked_states: self.revoked_states,
             new_split_outputs: self.new_split_outputs.clone(),
@@ -122,10 +122,10 @@ impl State0 {
             R_other,
             y_self: self.y_self,
             Y_other,
-            TX_c,
-            TX_s,
-            encsig_TX_c_self,
-            sig_TX_s_self,
+            tx_c,
+            tx_s,
+            encsig_tx_c_self,
+            sig_tx_s_self,
         };
 
         // NOTE: We assume that there's only one PTLC output
@@ -167,8 +167,8 @@ pub enum State1Kind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct SignaturesPtlcFunder {
-    encsig_TX_ptlc_redeem_funder: EncryptedSignature,
-    sig_TX_ptlc_refund_funder: Signature,
+    encsig_tx_ptlc_redeem_funder: EncryptedSignature,
+    sig_tx_ptlc_refund_funder: Signature,
 }
 
 /// Message sent by the PTLC redeemer in a channel update protocol execution
@@ -176,8 +176,8 @@ pub struct SignaturesPtlcFunder {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct SignaturesPtlcRedeemer {
-    sig_TX_ptlc_redeem_redeemer: Signature,
-    sig_TX_ptlc_refund_redeemer: Signature,
+    sig_tx_ptlc_redeem_redeemer: Signature,
+    sig_tx_ptlc_refund_redeemer: Signature,
 }
 
 /// A party who has exchanged `RevocationPublicKey`s and `PublishingPublicKey`s
@@ -187,66 +187,66 @@ pub struct SignaturesPtlcRedeemer {
 pub struct State1PtlcFunder {
     inner: State1,
     ptlc: Ptlc,
-    TX_ptlc_redeem: RedeemTransaction,
-    TX_ptlc_refund: RefundTransaction,
-    encsig_TX_ptlc_redeem_funder: EncryptedSignature,
-    sig_TX_ptlc_refund_funder: Signature,
+    tx_ptlc_redeem: RedeemTransaction,
+    tx_ptlc_refund: RefundTransaction,
+    encsig_tx_ptlc_redeem_funder: EncryptedSignature,
+    sig_tx_ptlc_refund_funder: Signature,
 }
 
 impl State1PtlcFunder {
     pub fn new(state: State1, ptlc: Ptlc) -> Result<Self> {
-        let TX_ptlc_redeem =
-            RedeemTransaction::new(&state.TX_s, ptlc.clone(), state.final_address_other.clone())?;
-        let encsig_TX_ptlc_redeem_funder = TX_ptlc_redeem.encsign_once(&state.x_self, ptlc.point());
+        let tx_ptlc_redeem =
+            RedeemTransaction::new(&state.tx_s, ptlc.clone(), state.final_address_other.clone())?;
+        let encsig_tx_ptlc_redeem_funder = tx_ptlc_redeem.encsign_once(&state.x_self, ptlc.point());
 
-        let TX_ptlc_refund =
-            RefundTransaction::new(&state.TX_s, ptlc.clone(), state.final_address_self.clone())?;
-        let sig_TX_ptlc_refund_funder = TX_ptlc_refund.sign_once(&state.x_self);
+        let tx_ptlc_refund =
+            RefundTransaction::new(&state.tx_s, ptlc.clone(), state.final_address_self.clone())?;
+        let sig_tx_ptlc_refund_funder = tx_ptlc_refund.sign_once(&state.x_self);
 
         Ok(Self {
             inner: state,
             ptlc,
-            TX_ptlc_redeem,
-            TX_ptlc_refund,
-            encsig_TX_ptlc_redeem_funder,
-            sig_TX_ptlc_refund_funder,
+            tx_ptlc_redeem,
+            tx_ptlc_refund,
+            encsig_tx_ptlc_redeem_funder,
+            sig_tx_ptlc_refund_funder,
         })
     }
 
     pub fn compose(&self) -> SignaturesPtlcFunder {
         SignaturesPtlcFunder {
-            encsig_TX_ptlc_redeem_funder: self.encsig_TX_ptlc_redeem_funder.clone(),
-            sig_TX_ptlc_refund_funder: self.sig_TX_ptlc_refund_funder.clone(),
+            encsig_tx_ptlc_redeem_funder: self.encsig_tx_ptlc_redeem_funder.clone(),
+            sig_tx_ptlc_refund_funder: self.sig_tx_ptlc_refund_funder.clone(),
         }
     }
 
     pub fn interpret(mut self, message: SignaturesPtlcRedeemer) -> Result<WithPtlc<State1>> {
-        self.TX_ptlc_refund
+        self.tx_ptlc_refund
             .verify_sig(
                 self.inner.X_other.clone(),
-                &message.sig_TX_ptlc_refund_redeemer,
+                &message.sig_tx_ptlc_refund_redeemer,
             )
-            .context("failed to verify sig_TX_ptlc_refund sent by PTLC redeemer")?;
-        self.TX_ptlc_refund.add_signatures(
+            .context("failed to verify sig_tx_ptlc_refund sent by PTLC redeemer")?;
+        self.tx_ptlc_refund.add_signatures(
             (
                 self.inner.x_self.public(),
-                self.sig_TX_ptlc_refund_funder.clone(),
+                self.sig_tx_ptlc_refund_funder.clone(),
             ),
             (
                 self.inner.X_other.clone(),
-                message.sig_TX_ptlc_refund_redeemer.clone(),
+                message.sig_tx_ptlc_refund_redeemer.clone(),
             ),
         )?;
 
         Ok(WithPtlc {
             state: self.inner,
             ptlc: self.ptlc,
-            TX_ptlc_redeem: self.TX_ptlc_redeem,
-            TX_ptlc_refund: self.TX_ptlc_refund,
-            encsig_TX_ptlc_redeem_funder: self.encsig_TX_ptlc_redeem_funder,
-            sig_TX_ptlc_redeem_redeemer: message.sig_TX_ptlc_redeem_redeemer,
-            sig_TX_ptlc_refund_funder: self.sig_TX_ptlc_refund_funder,
-            sig_TX_ptlc_refund_redeemer: message.sig_TX_ptlc_refund_redeemer,
+            tx_ptlc_redeem: self.tx_ptlc_redeem,
+            tx_ptlc_refund: self.tx_ptlc_refund,
+            encsig_tx_ptlc_redeem_funder: self.encsig_tx_ptlc_redeem_funder,
+            sig_tx_ptlc_redeem_redeemer: message.sig_tx_ptlc_redeem_redeemer,
+            sig_tx_ptlc_refund_funder: self.sig_tx_ptlc_refund_funder,
+            sig_tx_ptlc_refund_redeemer: message.sig_tx_ptlc_refund_redeemer,
         })
     }
 }
@@ -258,57 +258,57 @@ impl State1PtlcFunder {
 pub struct State1PtlcRedeemer {
     inner: State1,
     ptlc: Ptlc,
-    TX_ptlc_redeem: RedeemTransaction,
-    TX_ptlc_refund: RefundTransaction,
-    sig_TX_ptlc_redeem_redeemer: Signature,
-    sig_TX_ptlc_refund_redeemer: Signature,
+    tx_ptlc_redeem: RedeemTransaction,
+    tx_ptlc_refund: RefundTransaction,
+    sig_tx_ptlc_redeem_redeemer: Signature,
+    sig_tx_ptlc_refund_redeemer: Signature,
 }
 
 impl State1PtlcRedeemer {
     pub fn new(state: State1, ptlc: Ptlc) -> Result<Self> {
-        let TX_ptlc_redeem =
-            RedeemTransaction::new(&state.TX_s, ptlc.clone(), state.final_address_self.clone())?;
-        let sig_TX_ptlc_redeem_redeemer = TX_ptlc_redeem.sign_once(&state.x_self);
+        let tx_ptlc_redeem =
+            RedeemTransaction::new(&state.tx_s, ptlc.clone(), state.final_address_self.clone())?;
+        let sig_tx_ptlc_redeem_redeemer = tx_ptlc_redeem.sign_once(&state.x_self);
 
-        let TX_ptlc_refund =
-            RefundTransaction::new(&state.TX_s, ptlc.clone(), state.final_address_other.clone())?;
-        let sig_TX_ptlc_refund_redeemer = TX_ptlc_refund.sign_once(&state.x_self);
+        let tx_ptlc_refund =
+            RefundTransaction::new(&state.tx_s, ptlc.clone(), state.final_address_other.clone())?;
+        let sig_tx_ptlc_refund_redeemer = tx_ptlc_refund.sign_once(&state.x_self);
 
         Ok(Self {
             inner: state,
             ptlc,
-            TX_ptlc_redeem,
-            TX_ptlc_refund,
-            sig_TX_ptlc_redeem_redeemer,
-            sig_TX_ptlc_refund_redeemer,
+            tx_ptlc_redeem,
+            tx_ptlc_refund,
+            sig_tx_ptlc_redeem_redeemer,
+            sig_tx_ptlc_refund_redeemer,
         })
     }
 
     pub fn compose(&self) -> SignaturesPtlcRedeemer {
         SignaturesPtlcRedeemer {
-            sig_TX_ptlc_redeem_redeemer: self.sig_TX_ptlc_redeem_redeemer.clone(),
-            sig_TX_ptlc_refund_redeemer: self.sig_TX_ptlc_refund_redeemer.clone(),
+            sig_tx_ptlc_redeem_redeemer: self.sig_tx_ptlc_redeem_redeemer.clone(),
+            sig_tx_ptlc_refund_redeemer: self.sig_tx_ptlc_refund_redeemer.clone(),
         }
     }
 
     pub fn interpret(self, message: SignaturesPtlcFunder) -> Result<WithPtlc<State1>> {
-        self.TX_ptlc_redeem
+        self.tx_ptlc_redeem
             .verify_encsig(
                 self.inner.X_other.clone(),
                 self.ptlc.point().into(),
-                &message.encsig_TX_ptlc_redeem_funder,
+                &message.encsig_tx_ptlc_redeem_funder,
             )
-            .context("failed to verify encsig_TX_ptlc_redeem sent by PTLC funder")?;
+            .context("failed to verify encsig_tx_ptlc_redeem sent by PTLC funder")?;
 
         Ok(WithPtlc {
             state: self.inner,
             ptlc: self.ptlc,
-            TX_ptlc_redeem: self.TX_ptlc_redeem,
-            TX_ptlc_refund: self.TX_ptlc_refund,
-            encsig_TX_ptlc_redeem_funder: message.encsig_TX_ptlc_redeem_funder,
-            sig_TX_ptlc_redeem_redeemer: self.sig_TX_ptlc_redeem_redeemer,
-            sig_TX_ptlc_refund_funder: message.sig_TX_ptlc_refund_funder,
-            sig_TX_ptlc_refund_redeemer: self.sig_TX_ptlc_refund_redeemer,
+            tx_ptlc_redeem: self.tx_ptlc_redeem,
+            tx_ptlc_refund: self.tx_ptlc_refund,
+            encsig_tx_ptlc_redeem_funder: message.encsig_tx_ptlc_redeem_funder,
+            sig_tx_ptlc_redeem_redeemer: self.sig_tx_ptlc_redeem_redeemer,
+            sig_tx_ptlc_refund_funder: message.sig_tx_ptlc_refund_funder,
+            sig_tx_ptlc_refund_redeemer: self.sig_tx_ptlc_refund_redeemer,
         })
     }
 }
@@ -321,7 +321,7 @@ pub struct State1 {
     X_other: OwnershipPublicKey,
     final_address_self: Address,
     final_address_other: Address,
-    TX_f: FundingTransaction,
+    tx_f: FundingTransaction,
     current_state: ChannelState,
     revoked_states: Vec<RevokedState>,
     new_split_outputs: Vec<SplitOutput>,
@@ -329,32 +329,32 @@ pub struct State1 {
     R_other: RevocationPublicKey,
     y_self: PublishingKeyPair,
     Y_other: PublishingPublicKey,
-    TX_c: CommitTransaction,
-    TX_s: SplitTransaction,
-    encsig_TX_c_self: EncryptedSignature,
-    sig_TX_s_self: Signature,
+    tx_c: CommitTransaction,
+    tx_s: SplitTransaction,
+    encsig_tx_c_self: EncryptedSignature,
+    sig_tx_s_self: Signature,
 }
 
 impl State1 {
     pub fn compose(&self) -> ShareSplitSignature {
         ShareSplitSignature {
-            sig_TX_s: self.sig_TX_s_self.clone(),
+            sig_tx_s: self.sig_tx_s_self.clone(),
         }
     }
 
     pub fn interpret(
         mut self,
         ShareSplitSignature {
-            sig_TX_s: sig_TX_s_other,
+            sig_tx_s: sig_tx_s_other,
         }: ShareSplitSignature,
     ) -> Result<State2> {
-        self.TX_s
-            .verify_sig(self.X_other.clone(), &sig_TX_s_other)
-            .context("failed to verify sig_TX_s sent by counterparty")?;
+        self.tx_s
+            .verify_sig(self.X_other.clone(), &sig_tx_s_other)
+            .context("failed to verify sig_tx_s sent by counterparty")?;
 
-        self.TX_s.add_signatures(
-            (self.x_self.public(), self.sig_TX_s_self),
-            (self.X_other.clone(), sig_TX_s_other),
+        self.tx_s.add_signatures(
+            (self.x_self.public(), self.sig_tx_s_self),
+            (self.X_other.clone(), sig_tx_s_other),
         )?;
 
         Ok(State2 {
@@ -362,7 +362,7 @@ impl State1 {
             X_other: self.X_other,
             final_address_self: self.final_address_self,
             final_address_other: self.final_address_other,
-            TX_f: self.TX_f,
+            tx_f: self.tx_f,
             current_state: self.current_state,
             revoked_states: self.revoked_states,
             new_split_outputs: self.new_split_outputs,
@@ -370,9 +370,9 @@ impl State1 {
             R_other: self.R_other,
             y_self: self.y_self,
             Y_other: self.Y_other,
-            TX_c: self.TX_c,
-            signed_TX_s: self.TX_s,
-            encsig_TX_c_self: self.encsig_TX_c_self,
+            tx_c: self.tx_c,
+            signed_tx_s: self.tx_s,
+            encsig_tx_c_self: self.encsig_tx_c_self,
         })
     }
 }
@@ -386,7 +386,7 @@ pub struct State2 {
     X_other: OwnershipPublicKey,
     final_address_self: Address,
     final_address_other: Address,
-    TX_f: FundingTransaction,
+    tx_f: FundingTransaction,
     current_state: ChannelState,
     revoked_states: Vec<RevokedState>,
     new_split_outputs: Vec<SplitOutput>,
@@ -394,38 +394,38 @@ pub struct State2 {
     R_other: RevocationPublicKey,
     y_self: PublishingKeyPair,
     Y_other: PublishingPublicKey,
-    TX_c: CommitTransaction,
-    signed_TX_s: SplitTransaction,
-    encsig_TX_c_self: EncryptedSignature,
+    tx_c: CommitTransaction,
+    signed_tx_s: SplitTransaction,
+    encsig_tx_c_self: EncryptedSignature,
 }
 
 impl State2 {
     pub fn compose(&self) -> ShareCommitEncryptedSignature {
         ShareCommitEncryptedSignature {
-            encsig_TX_c: self.encsig_TX_c_self.clone(),
+            encsig_tx_c: self.encsig_tx_c_self.clone(),
         }
     }
 
     pub fn interpret(
         self,
         ShareCommitEncryptedSignature {
-            encsig_TX_c: encsig_TX_c_other,
+            encsig_tx_c: encsig_tx_c_other,
         }: ShareCommitEncryptedSignature,
     ) -> Result<State3> {
-        self.TX_c
+        self.tx_c
             .verify_encsig(
                 self.X_other.clone(),
                 self.y_self.public(),
-                &encsig_TX_c_other,
+                &encsig_tx_c_other,
             )
-            .context("failed to verify encsig_TX_c sent by counterparty")?;
+            .context("failed to verify encsig_tx_c sent by counterparty")?;
 
         Ok(State3 {
             x_self: self.x_self,
             X_other: self.X_other,
             final_address_self: self.final_address_self,
             final_address_other: self.final_address_other,
-            TX_f: self.TX_f,
+            tx_f: self.tx_f,
             current_state: self.current_state,
             revoked_states: self.revoked_states,
             new_split_outputs: self.new_split_outputs,
@@ -433,10 +433,10 @@ impl State2 {
             R_other: self.R_other,
             y_self: self.y_self,
             Y_other: self.Y_other,
-            TX_c: self.TX_c,
-            signed_TX_s: self.signed_TX_s,
-            encsig_TX_c_self: self.encsig_TX_c_self,
-            encsig_TX_c_other,
+            tx_c: self.tx_c,
+            signed_tx_s: self.signed_tx_s,
+            encsig_tx_c_self: self.encsig_tx_c_self,
+            encsig_tx_c_other,
         })
     }
 }
@@ -450,7 +450,7 @@ pub struct State3 {
     X_other: OwnershipPublicKey,
     final_address_self: Address,
     final_address_other: Address,
-    TX_f: FundingTransaction,
+    tx_f: FundingTransaction,
     current_state: ChannelState,
     revoked_states: Vec<RevokedState>,
     new_split_outputs: Vec<SplitOutput>,
@@ -458,10 +458,10 @@ pub struct State3 {
     R_other: RevocationPublicKey,
     y_self: PublishingKeyPair,
     Y_other: PublishingPublicKey,
-    TX_c: CommitTransaction,
-    signed_TX_s: SplitTransaction,
-    encsig_TX_c_self: EncryptedSignature,
-    encsig_TX_c_other: EncryptedSignature,
+    tx_c: CommitTransaction,
+    signed_tx_s: SplitTransaction,
+    encsig_tx_c_self: EncryptedSignature,
+    encsig_tx_c_other: EncryptedSignature,
 }
 
 impl State3 {
@@ -494,13 +494,13 @@ impl State3 {
                 &self.final_address_self,
                 &self.final_address_other,
             ),
-            TX_c: self.TX_c,
-            encsig_TX_c_other: self.encsig_TX_c_other,
+            tx_c: self.tx_c,
+            encsig_tx_c_other: self.encsig_tx_c_other,
             r_self: self.r_self,
             R_other: self.R_other,
             y_self: self.y_self,
             Y_other: self.Y_other,
-            signed_TX_s: self.signed_TX_s,
+            signed_tx_s: self.signed_tx_s,
         });
 
         Ok(Channel {
@@ -508,7 +508,7 @@ impl State3 {
             X_other: self.X_other,
             final_address_self: self.final_address_self,
             final_address_other: self.final_address_other,
-            TX_f_body: self.TX_f,
+            tx_f_body: self.tx_f,
             current_state,
             revoked_states,
         })
@@ -519,12 +519,12 @@ impl State3 {
 pub struct WithPtlc<S> {
     state: S,
     ptlc: Ptlc,
-    TX_ptlc_redeem: RedeemTransaction,
-    TX_ptlc_refund: RefundTransaction,
-    encsig_TX_ptlc_redeem_funder: EncryptedSignature,
-    sig_TX_ptlc_redeem_redeemer: Signature,
-    sig_TX_ptlc_refund_funder: Signature,
-    sig_TX_ptlc_refund_redeemer: Signature,
+    tx_ptlc_redeem: RedeemTransaction,
+    tx_ptlc_refund: RefundTransaction,
+    encsig_tx_ptlc_redeem_funder: EncryptedSignature,
+    sig_tx_ptlc_redeem_redeemer: Signature,
+    sig_tx_ptlc_refund_funder: Signature,
+    sig_tx_ptlc_refund_redeemer: Signature,
 }
 
 impl WithPtlc<State1> {
@@ -538,12 +538,12 @@ impl WithPtlc<State1> {
         Ok(WithPtlc {
             state,
             ptlc: self.ptlc,
-            TX_ptlc_redeem: self.TX_ptlc_redeem,
-            TX_ptlc_refund: self.TX_ptlc_refund,
-            encsig_TX_ptlc_redeem_funder: self.encsig_TX_ptlc_redeem_funder,
-            sig_TX_ptlc_redeem_redeemer: self.sig_TX_ptlc_redeem_redeemer,
-            sig_TX_ptlc_refund_funder: self.sig_TX_ptlc_refund_funder,
-            sig_TX_ptlc_refund_redeemer: self.sig_TX_ptlc_refund_redeemer,
+            tx_ptlc_redeem: self.tx_ptlc_redeem,
+            tx_ptlc_refund: self.tx_ptlc_refund,
+            encsig_tx_ptlc_redeem_funder: self.encsig_tx_ptlc_redeem_funder,
+            sig_tx_ptlc_redeem_redeemer: self.sig_tx_ptlc_redeem_redeemer,
+            sig_tx_ptlc_refund_funder: self.sig_tx_ptlc_refund_funder,
+            sig_tx_ptlc_refund_redeemer: self.sig_tx_ptlc_refund_redeemer,
         })
     }
 }
@@ -559,12 +559,12 @@ impl WithPtlc<State2> {
         Ok(WithPtlc {
             state,
             ptlc: self.ptlc,
-            TX_ptlc_redeem: self.TX_ptlc_redeem,
-            TX_ptlc_refund: self.TX_ptlc_refund,
-            encsig_TX_ptlc_redeem_funder: self.encsig_TX_ptlc_redeem_funder,
-            sig_TX_ptlc_redeem_redeemer: self.sig_TX_ptlc_redeem_redeemer,
-            sig_TX_ptlc_refund_funder: self.sig_TX_ptlc_refund_funder,
-            sig_TX_ptlc_refund_redeemer: self.sig_TX_ptlc_refund_redeemer,
+            tx_ptlc_redeem: self.tx_ptlc_redeem,
+            tx_ptlc_refund: self.tx_ptlc_refund,
+            encsig_tx_ptlc_redeem_funder: self.encsig_tx_ptlc_redeem_funder,
+            sig_tx_ptlc_redeem_redeemer: self.sig_tx_ptlc_redeem_redeemer,
+            sig_tx_ptlc_refund_funder: self.sig_tx_ptlc_refund_funder,
+            sig_tx_ptlc_refund_redeemer: self.sig_tx_ptlc_refund_redeemer,
         })
     }
 }
@@ -580,12 +580,12 @@ impl WithPtlc<State3> {
         let current_state = ChannelState::WithPtlc {
             inner: channel.current_state.into(),
             ptlc: self.ptlc,
-            TX_ptlc_redeem: self.TX_ptlc_redeem,
-            TX_ptlc_refund: self.TX_ptlc_refund,
-            encsig_TX_ptlc_redeem_funder: self.encsig_TX_ptlc_redeem_funder,
-            sig_TX_ptlc_redeem_redeemer: self.sig_TX_ptlc_redeem_redeemer,
-            sig_TX_ptlc_refund_funder: self.sig_TX_ptlc_refund_funder,
-            sig_TX_ptlc_refund_redeemer: self.sig_TX_ptlc_refund_redeemer,
+            tx_ptlc_redeem: self.tx_ptlc_redeem,
+            tx_ptlc_refund: self.tx_ptlc_refund,
+            encsig_tx_ptlc_redeem_funder: self.encsig_tx_ptlc_redeem_funder,
+            sig_tx_ptlc_redeem_redeemer: self.sig_tx_ptlc_redeem_redeemer,
+            sig_tx_ptlc_refund_funder: self.sig_tx_ptlc_refund_funder,
+            sig_tx_ptlc_refund_redeemer: self.sig_tx_ptlc_refund_redeemer,
         };
 
         channel.current_state = current_state;

--- a/thor/src/serde/partially_signed_transaction.rs
+++ b/thor/src/serde/partially_signed_transaction.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use bitcoin::{consensus::encode, util::psbt::PartiallySignedTransaction};
 use serde::{de::Error, Deserialize, Deserializer, Serializer};
 

--- a/thor/src/signature.rs
+++ b/thor/src/signature.rs
@@ -7,6 +7,7 @@ use ecdsa_fun::{
     Signature, ECDSA,
 };
 
+use anyhow::Result;
 use bitcoin::SigHash;
 use sha2::Sha256;
 

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     signature, Balance, Ptlc, SplitOutput, TX_FEE,
 };
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use arrayvec::ArrayVec;
 use bitcoin::{
     consensus::encode::serialize,
@@ -69,7 +69,7 @@ impl FundingTransaction {
         channel_balance: [(OwnershipPublicKey, Amount); 2],
     ) -> Result<Self> {
         if input_psbts.is_empty() {
-            anyhow::bail!("Cannot build a transaction without inputs")
+            bail!("Cannot build a transaction without inputs")
         }
 
         // Sort the tuples of arguments based on the ascending lexicographical order of
@@ -153,7 +153,7 @@ impl FundingTransaction {
 
     pub fn into_psbt(self) -> Result<PartiallySignedTransaction> {
         PartiallySignedTransaction::from_unsigned_tx(self.inner)
-            .map_err(|_| anyhow::anyhow!("could not convert to psbt"))
+            .map_err(|_| anyhow!("could not convert to psbt"))
     }
 
     pub fn txid(&self) -> Txid {
@@ -973,7 +973,7 @@ impl SpliceTransaction {
         channel_balance: [(OwnershipPublicKey, Amount); 2],
     ) -> Result<Self> {
         if inputs.is_empty() {
-            anyhow::bail!("Cannot build a transaction without inputs")
+            bail!("Cannot build a transaction without inputs")
         }
 
         // Sort the tuples of arguments based on the ascending lexicographical order of
@@ -1032,7 +1032,7 @@ impl SpliceTransaction {
 
     pub fn into_psbt(self) -> Result<PartiallySignedTransaction> {
         PartiallySignedTransaction::from_unsigned_tx(self.inner)
-            .map_err(|_| anyhow::anyhow!("could not convert to psbt"))
+            .map_err(|_| anyhow!("could not convert to psbt"))
     }
 
     fn compute_digest(&self, previous_TX_f: &FundingTransaction) -> SigHash {

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -21,6 +21,7 @@ use ecdsa_fun::{
     Signature,
 };
 use miniscript::{self, Descriptor, Segwitv0};
+use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use signature::{verify_encsig, verify_sig};
 use std::{collections::HashMap, str::FromStr};
@@ -51,7 +52,7 @@ impl FundOutput {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug)]
 pub(crate) struct FundingTransaction {
     inner: Transaction,
@@ -161,7 +162,7 @@ impl FundingTransaction {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CommitTransaction {
     inner: Transaction,
@@ -387,7 +388,7 @@ impl CommitTransaction {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct SplitTransaction {
     inner: Transaction,
@@ -950,7 +951,7 @@ pub(crate) fn balance(
     )
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug)]
 pub(crate) struct SpliceTransaction {
     inner: Transaction,

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -26,7 +26,8 @@ use sha2::Sha256;
 use signature::{verify_encsig, verify_sig};
 use std::{collections::HashMap, str::FromStr};
 
-pub mod ptlc;
+mod ptlc;
+pub(crate) use ptlc::{RedeemTransaction, RefundTransaction};
 
 #[derive(Clone, Debug)]
 pub(crate) struct FundOutput(miniscript::Descriptor<bitcoin::PublicKey>);

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -30,7 +30,7 @@ mod ptlc;
 pub(crate) use ptlc::{RedeemTransaction, RefundTransaction};
 
 #[derive(Clone, Debug)]
-pub(crate) struct FundOutput(miniscript::Descriptor<bitcoin::PublicKey>);
+pub(crate) struct FundOutput(Descriptor<bitcoin::PublicKey>);
 
 impl FundOutput {
     pub fn new(mut Xs: [OwnershipPublicKey; 2]) -> Self {
@@ -44,7 +44,7 @@ impl FundOutput {
         Self(descriptor)
     }
 
-    fn descriptor(&self) -> miniscript::Descriptor<bitcoin::PublicKey> {
+    fn descriptor(&self) -> Descriptor<bitcoin::PublicKey> {
         self.0.clone()
     }
 
@@ -57,7 +57,7 @@ impl FundOutput {
 #[derive(Clone, PartialEq, Debug)]
 pub(crate) struct FundingTransaction {
     inner: Transaction,
-    fund_output_descriptor: miniscript::Descriptor<bitcoin::PublicKey>,
+    fund_output_descriptor: Descriptor<bitcoin::PublicKey>,
     #[cfg_attr(
         feature = "serde",
         serde(with = "bitcoin::util::amount::serde::as_sat")
@@ -149,7 +149,7 @@ impl FundingTransaction {
         self.fund_output_amount
     }
 
-    pub fn fund_output_descriptor(&self) -> miniscript::Descriptor<bitcoin::PublicKey> {
+    pub fn fund_output_descriptor(&self) -> Descriptor<bitcoin::PublicKey> {
         self.fund_output_descriptor.clone()
     }
 
@@ -908,7 +908,7 @@ impl CloseTransaction {
 fn build_shared_output_descriptor(
     X_0: OwnershipPublicKey,
     X_1: OwnershipPublicKey,
-) -> miniscript::Descriptor<bitcoin::PublicKey> {
+) -> Descriptor<bitcoin::PublicKey> {
     // Describes the spending policy of the channel fund transaction TX_f.
     // For now we use `and(X_0, X_1)` - eventually we might want to replace this
     // with a threshold signature.
@@ -924,7 +924,7 @@ fn build_shared_output_descriptor(
     let miniscript = miniscript::Miniscript::<bitcoin::PublicKey, Segwitv0>::from_str(&miniscript)
         .expect("a valid miniscript");
 
-    miniscript::Descriptor::Wsh(miniscript)
+    Descriptor::Wsh(miniscript)
 }
 
 /// Calculate the balance held in the split outputs for the given final address
@@ -956,7 +956,7 @@ pub(crate) fn balance(
 #[derive(Clone, PartialEq, Debug)]
 pub(crate) struct SpliceTransaction {
     inner: Transaction,
-    fund_output_descriptor: miniscript::Descriptor<bitcoin::PublicKey>,
+    fund_output_descriptor: Descriptor<bitcoin::PublicKey>,
     #[cfg_attr(
         feature = "serde",
         serde(with = "bitcoin::util::amount::serde::as_sat")

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -114,7 +114,7 @@ impl FundingTransaction {
         };
 
         // Both parties _must_ insert inputs and outputs in the order defined above
-        let TX_f = Transaction {
+        let tx_f = Transaction {
             version: 2,
             lock_time: 0,
             input: inputs,
@@ -122,7 +122,7 @@ impl FundingTransaction {
         };
 
         Ok(Self {
-            inner: TX_f,
+            inner: tx_f,
             fund_output_descriptor,
             fund_output_amount,
         })
@@ -179,28 +179,28 @@ pub(crate) struct CommitTransaction {
 
 impl CommitTransaction {
     pub(crate) fn new(
-        TX_f: &FundingTransaction,
+        tx_f: &FundingTransaction,
         keys: [(OwnershipPublicKey, RevocationPublicKey, PublishingPublicKey); 2],
         time_lock: u32,
     ) -> Result<Self> {
         let output_descriptor = Self::build_descriptor(keys, time_lock)?;
 
-        let input = TX_f.as_txin();
+        let input = tx_f.as_txin();
         let fee = Amount::from_sat(TX_FEE);
-        let TX_c = Transaction {
+        let tx_c = Transaction {
             version: 2,
             lock_time: 0,
             input: vec![input],
             output: vec![TxOut {
-                value: TX_f.value().as_sat() - fee.as_sat(),
+                value: tx_f.value().as_sat() - fee.as_sat(),
                 script_pubkey: output_descriptor.script_pubkey(),
             }],
         };
 
-        let digest = Self::compute_digest(&TX_c, TX_f);
+        let digest = Self::compute_digest(&tx_c, tx_f);
 
         Ok(Self {
-            inner: TX_c,
+            inner: tx_c,
             output_descriptor,
             time_lock,
             digest,
@@ -223,7 +223,7 @@ impl CommitTransaction {
     /// Add signatures to CommitTransaction.
     pub fn add_signatures(
         self,
-        TX_f: &FundingTransaction,
+        tx_f: &FundingTransaction,
         (X_0, sig_0): (OwnershipPublicKey, Signature),
         (X_1, sig_1): (OwnershipPublicKey, Signature),
     ) -> Result<Transaction> {
@@ -246,18 +246,18 @@ impl CommitTransaction {
             satisfier
         };
 
-        let mut TX_c = self.inner;
-        TX_f.fund_output_descriptor()
-            .satisfy(&mut TX_c.input[0], satisfier)?;
+        let mut tx_c = self.inner;
+        tx_f.fund_output_descriptor()
+            .satisfy(&mut tx_c.input[0], satisfier)?;
 
-        Ok(TX_c)
+        Ok(tx_c)
     }
 
     /// Use `CommitTransaction` as a Transaction Input for the
     /// `SplitTransaction`. The sequence number is set to the value of
     /// `time_lock` since the `SplitTransaction` uses the time-locked path
     /// of the `CommitTransaction`'s script.
-    pub fn as_txin_for_TX_s(&self) -> TxIn {
+    pub fn as_txin_for_tx_s(&self) -> TxIn {
         TxIn {
             previous_output: OutPoint::new(self.inner.txid(), 0),
             script_sig: Script::new(),
@@ -270,7 +270,7 @@ impl CommitTransaction {
     /// `PunishTransaction`. The sequence number is set to `OxFFFF_FFFF` since
     /// the `PunishTransaction` does not use the time-locked path of the
     /// `CommitTransaction`'s script.
-    pub fn as_txin_for_TX_p(&self) -> TxIn {
+    pub fn as_txin_for_tx_p(&self) -> TxIn {
         TxIn {
             previous_output: OutPoint::new(self.inner.txid(), 0),
             script_sig: Script::new(),
@@ -316,11 +316,11 @@ impl CommitTransaction {
     }
 
     // TODO: Remove code duplication.
-    fn compute_digest(TX_c: &Transaction, TX_f: &FundingTransaction) -> SigHash {
-        SighashComponents::new(&TX_c).sighash_all(
-            &TX_f.as_txin(),
-            &TX_f.fund_output_descriptor().witness_script(),
-            TX_f.value().as_sat(),
+    fn compute_digest(tx_c: &Transaction, tx_f: &FundingTransaction) -> SigHash {
+        SighashComponents::new(&tx_c).sighash_all(
+            &tx_f.as_txin(),
+            &tx_f.fund_output_descriptor().witness_script(),
+            tx_f.value().as_sat(),
         )
     }
 
@@ -357,7 +357,7 @@ impl CommitTransaction {
         let Y_0_hash = hash160::Hash::hash(&Y_0.serialize()[..]);
         let Y_1_hash = hash160::Hash::hash(&Y_1.serialize()[..]);
 
-        // Describes the spending policy of the channel commit transaction TX_c.
+        // Describes the spending policy of the channel commit transaction tx_c.
         // There are three possible way to spend this transaction:
         // 1. Channel state: It is correctly signed w.r.t X_0, X_1 and after relative
         // timelock
@@ -409,45 +409,45 @@ pub enum FeeError {
         fee: Amount,
     },
     #[error(
-        "Total output {total_output} is less than the sum of fees to be paid: {TX_c_fee} &
-    {TX_s_fee}"
+        "Total output {total_output} is less than the sum of fees to be paid: {tx_c_fee} &
+    {tx_s_fee}"
     )]
     DustOutput {
         total_output: Amount,
-        TX_c_fee: Amount,
-        TX_s_fee: Amount,
+        tx_c_fee: Amount,
+        tx_s_fee: Amount,
     },
-    #[error("Total output {total_output} should equal the value of the TX_c output {TX_c_value}")]
+    #[error("Total output {total_output} should equal the value of the tx_c output {tx_c_value}")]
     OutputMismatch {
-        TX_c_value: Amount,
+        tx_c_value: Amount,
         total_output: Amount,
     },
 }
 
 impl SplitTransaction {
     pub(crate) fn new(
-        TX_c: &CommitTransaction,
+        tx_c: &CommitTransaction,
         outputs: Vec<SplitOutput>,
     ) -> Result<Self, FeeError> {
-        let total_input = TX_c.value();
+        let total_input = tx_c.value();
         let total_output =
             Amount::from_sat(outputs.iter().map(|output| output.amount().as_sat()).sum());
-        let TX_s_fee = Amount::from_sat(TX_FEE);
-        if total_input < total_output - TX_c.fee() - TX_s_fee {
+        let tx_s_fee = Amount::from_sat(TX_FEE);
+        if total_input < total_output - tx_c.fee() - tx_s_fee {
             return Err(FeeError::InsufficientFunds {
                 input: total_input,
-                output: total_output - TX_c.fee(),
-                fee: TX_s_fee,
+                output: total_output - tx_c.fee(),
+                fee: tx_s_fee,
             });
         }
 
         let n_outputs = outputs.len();
 
-        // Distribute transaction TX_c fee costs evenly between outputs
-        let TX_c_fee_per_output = TX_c.fee() / n_outputs as u64;
+        // Distribute transaction tx_c fee costs evenly between outputs
+        let tx_c_fee_per_output = tx_c.fee() / n_outputs as u64;
 
-        // Distribute transaction TX_s fee costs evenly between outputs
-        let TX_s_fee_per_output = TX_s_fee / n_outputs as u64;
+        // Distribute transaction tx_s fee costs evenly between outputs
+        let tx_s_fee_per_output = tx_s_fee / n_outputs as u64;
 
         let mut outputs = outputs
             .iter()
@@ -483,7 +483,7 @@ impl SplitTransaction {
                     // Distribute transaction fee costs evenly between outputs
                     // TODO: Currently fails if there value is too small. Proposal would be to
                     // exclude outputs smaller than the fees
-                    value: value - TX_c_fee_per_output.as_sat() - TX_s_fee_per_output.as_sat(),
+                    value: value - tx_c_fee_per_output.as_sat() - tx_s_fee_per_output.as_sat(),
                     script_pubkey,
                 },
             )
@@ -494,10 +494,10 @@ impl SplitTransaction {
         // transaction
         outputs.sort_by(|a, b| a.script_pubkey.cmp(&b.script_pubkey));
 
-        let input = TX_c.as_txin_for_TX_s();
+        let input = tx_c.as_txin_for_tx_s();
 
         // Both parties _must_ insert the outputs in the order defined above
-        let TX_s = {
+        let tx_s = {
             Transaction {
                 version: 2,
                 lock_time: 0,
@@ -506,12 +506,12 @@ impl SplitTransaction {
             }
         };
 
-        let digest = Self::compute_digest(&TX_s, TX_c);
+        let digest = Self::compute_digest(&tx_s, tx_c);
 
-        let input_descriptor = TX_c.output_descriptor();
+        let input_descriptor = tx_c.output_descriptor();
 
         Ok(Self {
-            inner: TX_s,
+            inner: tx_s,
             input_descriptor,
             digest,
         })
@@ -520,39 +520,39 @@ impl SplitTransaction {
     // TODO: use it
     #[allow(dead_code)]
     pub(crate) fn fees(
-        TX_c_value: Amount,
-        TX_c_fee: Amount,
+        tx_c_value: Amount,
+        tx_c_fee: Amount,
         amount_0: Amount,
         amount_1: Amount,
     ) -> Result<(Amount, Amount), FeeError> {
         let total_output = amount_0 + amount_1;
-        let TX_s_fee = Amount::from_sat(TX_FEE);
+        let tx_s_fee = Amount::from_sat(TX_FEE);
 
-        if total_output != TX_c_value {
+        if total_output != tx_c_value {
             return Err(FeeError::OutputMismatch {
-                TX_c_value,
+                tx_c_value,
                 total_output,
             });
         }
 
-        if total_output < TX_c_fee + TX_s_fee {
+        if total_output < tx_c_fee + tx_s_fee {
             return Err(FeeError::DustOutput {
                 total_output,
-                TX_c_fee,
-                TX_s_fee,
+                tx_c_fee,
+                tx_s_fee,
             });
         }
 
-        if TX_c_value <= total_output - TX_c_fee - TX_s_fee {
+        if tx_c_value <= total_output - tx_c_fee - tx_s_fee {
             return Err(FeeError::InsufficientFunds {
-                input: TX_c_value,
-                output: total_output - TX_c_fee,
-                fee: TX_s_fee,
+                input: tx_c_value,
+                output: total_output - tx_c_fee,
+                fee: tx_s_fee,
             });
         }
 
-        // Distribute transaction TX_c & TX_s fee costs evenly between outputs
-        let half_the_fees = (TX_c_fee + TX_s_fee) / 2;
+        // Distribute transaction tx_c & tx_s fee costs evenly between outputs
+        let half_the_fees = (tx_c_fee + tx_s_fee) / 2;
 
         // Fee allocation: if a side does not have enough to pay the fees, the other
         // side pay their part.
@@ -639,11 +639,11 @@ impl SplitTransaction {
         self.inner.txid()
     }
 
-    fn compute_digest(TX_s: &Transaction, TX_c: &CommitTransaction) -> SigHash {
-        SighashComponents::new(&TX_s).sighash_all(
-            &TX_c.as_txin_for_TX_s(),
-            &TX_c.output_descriptor().witness_script(),
-            TX_c.value().as_sat(),
+    fn compute_digest(tx_s: &Transaction, tx_c: &CommitTransaction) -> SigHash {
+        SighashComponents::new(&tx_s).sighash_all(
+            &tx_c.as_txin_for_tx_s(),
+            &tx_c.output_descriptor().witness_script(),
+            tx_c.value().as_sat(),
         )
     }
 }
@@ -669,16 +669,16 @@ impl PunishTransaction {
     pub(crate) fn new(
         x_self: &OwnershipKeyPair,
         final_address: Address,
-        TX_c: &CommitTransaction,
-        encsig_TX_c_self: &EncryptedSignature,
+        tx_c: &CommitTransaction,
+        encsig_tx_c_self: &EncryptedSignature,
         r_other: &RevocationKeyPair,
         Y_other: PublishingPublicKey,
-        revoked_TX_c_candidate: Transaction,
+        revoked_tx_c_candidate: Transaction,
     ) -> Result<Self> {
         let adaptor = Adaptor::<Sha256, Deterministic<Sha256>>::default();
 
         // CommitTransaction's only have one input
-        let input = revoked_TX_c_candidate.input[0].clone();
+        let input = revoked_tx_c_candidate.input[0].clone();
 
         // Extract all signatures from witness stack
         let mut sigs = Vec::new();
@@ -703,25 +703,25 @@ impl PunishTransaction {
             .into_iter()
             .find_map(|sig| {
                 adaptor
-                    .recover_decryption_key(&Y_other.clone().into(), &sig.into(), &encsig_TX_c_self)
+                    .recover_decryption_key(&Y_other.clone().into(), &sig.into(), &encsig_tx_c_self)
                     .map(PublishingKeyPair::from)
             })
             .ok_or_else(|| PunishError::RecoveryFailure)?;
 
-        let mut TX_p = {
+        let mut tx_p = {
             let output = TxOut {
-                value: TX_c.value().as_sat() - TX_FEE,
+                value: tx_c.value().as_sat() - TX_FEE,
                 script_pubkey: final_address.script_pubkey(),
             };
             Transaction {
                 version: 2,
                 lock_time: 0,
-                input: vec![TX_c.as_txin_for_TX_p()],
+                input: vec![tx_c.as_txin_for_tx_p()],
                 output: vec![output],
             }
         };
 
-        let digest = Self::compute_digest(&TX_p, &TX_c);
+        let digest = Self::compute_digest(&tx_p, &tx_c);
 
         let satisfier = {
             let mut satisfier = HashMap::with_capacity(3);
@@ -767,17 +767,17 @@ impl PunishTransaction {
             satisfier
         };
 
-        TX_c.output_descriptor()
-            .satisfy(&mut TX_p.input[0], satisfier)?;
+        tx_c.output_descriptor()
+            .satisfy(&mut tx_p.input[0], satisfier)?;
 
-        Ok(Self(TX_p))
+        Ok(Self(tx_p))
     }
 
-    fn compute_digest(TX_p: &Transaction, TX_c: &CommitTransaction) -> SigHash {
-        SighashComponents::new(&TX_p).sighash_all(
-            &TX_c.as_txin_for_TX_p(),
-            &TX_c.output_descriptor().witness_script(),
-            TX_c.value().as_sat(),
+    fn compute_digest(tx_p: &Transaction, tx_c: &CommitTransaction) -> SigHash {
+        SighashComponents::new(&tx_p).sighash_all(
+            &tx_c.as_txin_for_tx_p(),
+            &tx_c.output_descriptor().witness_script(),
+            tx_c.value().as_sat(),
         )
     }
 }
@@ -797,10 +797,10 @@ pub(crate) struct CloseTransaction {
 
 impl CloseTransaction {
     pub(crate) fn new(
-        TX_f: &FundingTransaction,
+        tx_f: &FundingTransaction,
         mut outputs: [(Amount, Address); 2],
     ) -> Result<Self, FeeError> {
-        let total_input = TX_f.value();
+        let total_input = tx_f.value();
         let total_output =
             Amount::from_sat(outputs.iter().map(|(amount, _)| amount.as_sat()).sum());
         let close_transaction_fee = Amount::from_sat(TX_FEE);
@@ -832,7 +832,7 @@ impl CloseTransaction {
             script_pubkey: address_1.script_pubkey(),
         };
 
-        let input = TX_f.as_txin();
+        let input = tx_f.as_txin();
 
         // Both parties _must_ insert the outputs in the order defined above
         let close_transaction = Transaction {
@@ -842,20 +842,20 @@ impl CloseTransaction {
             output: vec![output_0, output_1],
         };
 
-        let digest = Self::compute_digest(&close_transaction, &TX_f);
+        let digest = Self::compute_digest(&close_transaction, &tx_f);
 
         Ok(Self {
             inner: close_transaction,
-            input_descriptor: TX_f.fund_output_descriptor(),
+            input_descriptor: tx_f.fund_output_descriptor(),
             digest,
         })
     }
 
-    fn compute_digest(close_transaction: &Transaction, TX_f: &FundingTransaction) -> SigHash {
+    fn compute_digest(close_transaction: &Transaction, tx_f: &FundingTransaction) -> SigHash {
         SighashComponents::new(&close_transaction).sighash_all(
-            &TX_f.as_txin(),
-            &TX_f.fund_output_descriptor().witness_script(),
-            TX_f.value().as_sat(),
+            &tx_f.as_txin(),
+            &tx_f.fund_output_descriptor().witness_script(),
+            tx_f.value().as_sat(),
         )
     }
 
@@ -909,7 +909,7 @@ fn build_shared_output_descriptor(
     X_0: OwnershipPublicKey,
     X_1: OwnershipPublicKey,
 ) -> Descriptor<bitcoin::PublicKey> {
-    // Describes the spending policy of the channel fund transaction TX_f.
+    // Describes the spending policy of the channel fund transaction tx_f.
     // For now we use `and(X_0, X_1)` - eventually we might want to replace this
     // with a threshold signature.
     const MINISCRIPT_TEMPLATE: &str = "c:and_v(v:pk(X_0),pk_k(X_1))";
@@ -1017,7 +1017,7 @@ impl SpliceTransaction {
         };
 
         // Both parties _must_ insert inputs and outputs in the order defined above
-        let TX_f = Transaction {
+        let tx_f = Transaction {
             version: 2,
             lock_time: 0,
             input: inputs,
@@ -1025,7 +1025,7 @@ impl SpliceTransaction {
         };
 
         Ok(Self {
-            inner: TX_f,
+            inner: tx_f,
             fund_output_descriptor,
             amount_0,
             amount_1,
@@ -1037,20 +1037,20 @@ impl SpliceTransaction {
             .map_err(|_| anyhow!("could not convert to psbt"))
     }
 
-    fn compute_digest(&self, previous_TX_f: &FundingTransaction) -> SigHash {
+    fn compute_digest(&self, previous_tx_f: &FundingTransaction) -> SigHash {
         SighashComponents::new(&self.inner).sighash_all(
-            &previous_TX_f.as_txin(),
-            &previous_TX_f.fund_output_descriptor().witness_script(),
-            previous_TX_f.value().as_sat(),
+            &previous_tx_f.as_txin(),
+            &previous_tx_f.fund_output_descriptor().witness_script(),
+            previous_tx_f.value().as_sat(),
         )
     }
 
     pub fn sign_once(
         &self,
         x_self: OwnershipKeyPair,
-        previous_TX_f: &FundingTransaction,
+        previous_tx_f: &FundingTransaction,
     ) -> Signature {
-        let digest = self.compute_digest(previous_TX_f);
+        let digest = self.compute_digest(previous_tx_f);
         x_self.sign(digest)
     }
 }
@@ -1154,14 +1154,14 @@ mod tests {
     proptest! {
         #[test]
         fn check_fees_are_unreachable(
-                TX_c_value in arb_amount(),
-                TX_c_fee in arb_amount(),
+                tx_c_value in arb_amount(),
+                tx_c_fee in arb_amount(),
                 amount_0 in arb_amount(),
                 amount_1 in arb_amount()
             ) {
                 let _ = SplitTransaction::fees(
-                            TX_c_value,
-                            TX_c_fee,
+                            tx_c_value,
+                            tx_c_fee,
                             amount_0,
                             amount_1,
                         );

--- a/thor/src/transaction/ptlc.rs
+++ b/thor/src/transaction/ptlc.rs
@@ -5,7 +5,7 @@ use crate::{
     Ptlc, PtlcPoint, TX_FEE,
 };
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use bitcoin::{
     util::bip143::SighashComponents, Address, OutPoint, Script, SigHash, Transaction, TxIn, TxOut,
 };
@@ -169,7 +169,7 @@ pub(crate) fn spend_transaction(
         .output
         .iter()
         .position(|output| output.script_pubkey == ptlc_output_descriptor.script_pubkey())
-        .ok_or_else(|| anyhow::anyhow!("TX_s does not contain PTLC output"))?;
+        .ok_or_else(|| anyhow!("TX_s does not contain PTLC output"))?;
 
     #[allow(clippy::cast_possible_truncation)]
     let input = TxIn {

--- a/thor/src/transaction/ptlc.rs
+++ b/thor/src/transaction/ptlc.rs
@@ -11,10 +11,11 @@ use bitcoin::{
 };
 use ecdsa_fun::{self, adaptor::EncryptedSignature, fun::Point, Signature};
 use miniscript::Descriptor;
+use serde::{Deserialize, Serialize};
 use signature::{verify_encsig, verify_sig};
 use std::collections::HashMap;
 
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub(crate) struct RedeemTransaction {
     inner: Transaction,
@@ -86,7 +87,7 @@ impl RedeemTransaction {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub(crate) struct RefundTransaction {
     inner: Transaction,

--- a/thor/src/transaction/ptlc.rs
+++ b/thor/src/transaction/ptlc.rs
@@ -5,6 +5,7 @@ use crate::{
     Ptlc, PtlcPoint, TX_FEE,
 };
 
+use anyhow::Result;
 use bitcoin::{
     util::bip143::SighashComponents, Address, OutPoint, Script, SigHash, Transaction, TxIn, TxOut,
 };
@@ -22,11 +23,7 @@ pub(crate) struct RedeemTransaction {
 }
 
 impl RedeemTransaction {
-    pub fn new(
-        TX_s: &SplitTransaction,
-        ptlc: Ptlc,
-        redeem_address: Address,
-    ) -> anyhow::Result<Self> {
+    pub fn new(TX_s: &SplitTransaction, ptlc: Ptlc, redeem_address: Address) -> Result<Self> {
         let (transaction, digest, input_descriptor) =
             spend_transaction(TX_s, ptlc, redeem_address, 0xFFFF_FFFF)?;
 
@@ -49,7 +46,7 @@ impl RedeemTransaction {
         &self,
         (X_0, sig_0): (OwnershipPublicKey, Signature),
         (X_1, sig_1): (OwnershipPublicKey, Signature),
-    ) -> anyhow::Result<Transaction> {
+    ) -> Result<Transaction> {
         let satisfier = {
             let mut satisfier = HashMap::with_capacity(2);
 
@@ -82,7 +79,7 @@ impl RedeemTransaction {
         verification_key: OwnershipPublicKey,
         encryption_key: Point,
         encsig: &EncryptedSignature,
-    ) -> anyhow::Result<()> {
+    ) -> Result<()> {
         verify_encsig(verification_key, encryption_key, &self.digest, encsig)?;
 
         Ok(())
@@ -98,11 +95,7 @@ pub(crate) struct RefundTransaction {
 }
 
 impl RefundTransaction {
-    pub fn new(
-        TX_s: &SplitTransaction,
-        ptlc: Ptlc,
-        refund_address: Address,
-    ) -> anyhow::Result<Self> {
+    pub fn new(TX_s: &SplitTransaction, ptlc: Ptlc, refund_address: Address) -> Result<Self> {
         let (transaction, digest, input_descriptor) =
             spend_transaction(TX_s, ptlc.clone(), refund_address, ptlc.refund_time_lock)?;
 
@@ -121,7 +114,7 @@ impl RefundTransaction {
         &self,
         verification_key: OwnershipPublicKey,
         signature: &Signature,
-    ) -> anyhow::Result<()> {
+    ) -> Result<()> {
         verify_sig(verification_key, &self.digest, signature)?;
 
         Ok(())
@@ -131,7 +124,7 @@ impl RefundTransaction {
         &mut self,
         (X_0, sig_0): (OwnershipPublicKey, Signature),
         (X_1, sig_1): (OwnershipPublicKey, Signature),
-    ) -> anyhow::Result<()> {
+    ) -> Result<()> {
         let satisfier = {
             let mut satisfier = HashMap::with_capacity(2);
 
@@ -165,7 +158,7 @@ pub(crate) fn spend_transaction(
     ptlc: Ptlc,
     refund_address: Address,
     input_sequence: u32,
-) -> anyhow::Result<(Transaction, SigHash, Descriptor<bitcoin::PublicKey>)> {
+) -> Result<(Transaction, SigHash, Descriptor<bitcoin::PublicKey>)> {
     let mut Xs = [ptlc.X_funder, ptlc.X_redeemer];
     Xs.sort_by(|a, b| a.partial_cmp(b).expect("comparison is possible"));
     let [X_0, X_1] = Xs;

--- a/thor/tests/e2e.rs
+++ b/thor/tests/e2e.rs
@@ -169,19 +169,19 @@ fn e2e_punish_publication_of_revoked_commit_transaction() {
 
     // Alice attempts to cheat by publishing a revoked commit transaction
 
-    let signed_revoked_TX_c = alice_channel.latest_revoked_signed_TX_c().unwrap().unwrap();
+    let signed_revoked_tx_c = alice_channel.latest_revoked_signed_tx_c().unwrap().unwrap();
     runtime
         .block_on(
             alice_wallet
                 .0
-                .send_raw_transaction(signed_revoked_TX_c.clone()),
+                .send_raw_transaction(signed_revoked_tx_c.clone()),
         )
         .unwrap();
 
     // Bob sees the transaction and punishes Alice
 
     runtime
-        .block_on(bob_channel.punish(&bob_wallet, signed_revoked_TX_c))
+        .block_on(bob_channel.punish(&bob_wallet, signed_revoked_tx_c))
         .unwrap();
 
     let after_punish_balance_alice = runtime.block_on(alice_wallet.0.balance()).unwrap();
@@ -862,7 +862,7 @@ fn e2e_atomic_swap_happy() {
     let point = secret.point();
     let ptlc_amount = Amount::from_btc(0.5).unwrap();
 
-    let (alpha_absolute_expiry, TX_s_time_lock, ptlc_redeem_time_lock) = (1_598_875_222, 1, 1);
+    let (alpha_absolute_expiry, tx_s_time_lock, ptlc_redeem_time_lock) = (1_598_875_222, 1, 1);
 
     let swap_beta_ptlc_alice = alice_channel.swap_beta_ptlc_alice(
         &mut alice_transport,
@@ -870,7 +870,7 @@ fn e2e_atomic_swap_happy() {
         ptlc_amount,
         secret,
         alpha_absolute_expiry,
-        TX_s_time_lock,
+        tx_s_time_lock,
         ptlc_redeem_time_lock,
     );
 
@@ -881,7 +881,7 @@ fn e2e_atomic_swap_happy() {
         ptlc_amount,
         point,
         alpha_absolute_expiry,
-        TX_s_time_lock,
+        tx_s_time_lock,
         ptlc_redeem_time_lock,
         skip_final_update,
     );
@@ -959,7 +959,7 @@ fn e2e_atomic_swap_unresponsive_bob_after_secret_reveal() {
 
     // TODO: produce redeem and refund transactions + fund alpha
 
-    let (alpha_absolute_expiry, TX_s_time_lock, ptlc_redeem_time_lock) = (1_598_875_222, 1, 1);
+    let (alpha_absolute_expiry, tx_s_time_lock, ptlc_redeem_time_lock) = (1_598_875_222, 1, 1);
 
     let swap_beta_ptlc_alice = alice_channel.swap_beta_ptlc_alice(
         &mut alice_transport,
@@ -967,7 +967,7 @@ fn e2e_atomic_swap_unresponsive_bob_after_secret_reveal() {
         ptlc_amount,
         secret,
         alpha_absolute_expiry,
-        TX_s_time_lock,
+        tx_s_time_lock,
         ptlc_redeem_time_lock,
     );
 
@@ -978,7 +978,7 @@ fn e2e_atomic_swap_unresponsive_bob_after_secret_reveal() {
         ptlc_amount,
         point,
         alpha_absolute_expiry,
-        TX_s_time_lock,
+        tx_s_time_lock,
         ptlc_redeem_time_lock,
         skip_final_update,
     );
@@ -1031,7 +1031,7 @@ async fn swap_beta_ptlc_bob(
     ptlc_amount: Amount,
     point: PtlcPoint,
     alpha_absolute_expiry: u32,
-    TX_s_time_lock: u32,
+    tx_s_time_lock: u32,
     ptlc_redeem_time_lock: u32,
     skip_update: bool,
 ) -> Result<()> {
@@ -1040,7 +1040,7 @@ async fn swap_beta_ptlc_bob(
         ptlc_amount,
         point,
         alpha_absolute_expiry,
-        TX_s_time_lock,
+        tx_s_time_lock,
         ptlc_redeem_time_lock,
     );
 

--- a/thor/tests/e2e.rs
+++ b/thor/tests/e2e.rs
@@ -2,6 +2,7 @@
 
 mod harness;
 
+use anyhow::Result;
 use bitcoin::Amount;
 use bitcoin_harness::{self, Bitcoind};
 use genawaiter::GeneratorState;
@@ -1033,7 +1034,7 @@ async fn swap_beta_ptlc_bob(
     TX_s_time_lock: u32,
     ptlc_redeem_time_lock: u32,
     skip_update: bool,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let mut swap_beta_ptlc_bob = channel.swap_beta_ptlc_bob(
         bob_transport,
         ptlc_amount,

--- a/thor/tests/harness/transport.rs
+++ b/thor/tests/harness/transport.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use futures::{
     channel::mpsc::{Receiver, Sender},
     SinkExt, StreamExt,
@@ -39,7 +39,7 @@ impl SendMessage for Transport {
         self.sender
             .send(str)
             .await
-            .map_err(|_| anyhow::anyhow!("failed to send message"))
+            .map_err(|_| anyhow!("failed to send message"))
     }
 }
 
@@ -50,7 +50,7 @@ impl ReceiveMessage for Transport {
             .receiver
             .next()
             .await
-            .ok_or_else(|| anyhow::anyhow!("failed to receive message"))?;
+            .ok_or_else(|| anyhow!("failed to receive message"))?;
         let message = serde_json::from_str(&str).context("failed to decode message")?;
         Ok(message)
     }

--- a/thor/tests/harness/transport.rs
+++ b/thor/tests/harness/transport.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use futures::{
-    channel::mpsc::{Receiver, Sender},
+    channel::mpsc::{self, Receiver, Sender},
     SinkExt, StreamExt,
 };
 use thor::{Message, ReceiveMessage, SendMessage};
@@ -17,8 +17,8 @@ pub struct Transport {
 /// parties, allowing them to send and receive `thor::Message`s to and from each
 /// other.
 pub fn make_transports() -> (Transport, Transport) {
-    let (alice_sender, bob_receiver) = futures::channel::mpsc::channel(5);
-    let (bob_sender, alice_receiver) = futures::channel::mpsc::channel(5);
+    let (alice_sender, bob_receiver) = mpsc::channel(5);
+    let (bob_sender, alice_receiver) = mpsc::channel(5);
 
     let alice_transport = Transport {
         sender: alice_sender,

--- a/thor/tests/harness/transport.rs
+++ b/thor/tests/harness/transport.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{Context, Result};
 use futures::{
     channel::mpsc::{Receiver, Sender},
     SinkExt, StreamExt,
@@ -34,7 +34,7 @@ pub fn make_transports() -> (Transport, Transport) {
 
 #[async_trait::async_trait]
 impl SendMessage for Transport {
-    async fn send_message(&mut self, message: Message) -> anyhow::Result<()> {
+    async fn send_message(&mut self, message: Message) -> Result<()> {
         let str = serde_json::to_string(&message).context("failed to encode message")?;
         self.sender
             .send(str)
@@ -45,7 +45,7 @@ impl SendMessage for Transport {
 
 #[async_trait::async_trait]
 impl ReceiveMessage for Transport {
-    async fn receive_message(&mut self) -> anyhow::Result<Message> {
+    async fn receive_message(&mut self) -> Result<Message> {
         let str = self
             .receiver
             .next()

--- a/thor/tests/harness/transport.rs
+++ b/thor/tests/harness/transport.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
 use futures::{
     channel::mpsc::{Receiver, Sender},
     SinkExt, StreamExt,
@@ -32,7 +33,7 @@ pub fn make_transports() -> (Transport, Transport) {
     (alice_transport, bob_transport)
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl SendMessage for Transport {
     async fn send_message(&mut self, message: Message) -> Result<()> {
         let str = serde_json::to_string(&message).context("failed to encode message")?;
@@ -43,7 +44,7 @@ impl SendMessage for Transport {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl ReceiveMessage for Transport {
     async fn receive_message(&mut self) -> Result<Message> {
         let str = self

--- a/thor/tests/harness/wallet.rs
+++ b/thor/tests/harness/wallet.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount};
 use bitcoin_harness::{bitcoind_rpc::PsbtBase64, Bitcoind};
 use reqwest::Url;
@@ -6,7 +7,7 @@ use thor::{BroadcastSignedTransaction, BuildFundingPSBT, NewAddress, SignFunding
 pub struct Wallet(pub bitcoin_harness::Wallet);
 
 impl Wallet {
-    async fn new(name: &str, url: Url) -> anyhow::Result<Self> {
+    async fn new(name: &str, url: Url) -> Result<Self> {
         let wallet = bitcoin_harness::Wallet::new(name, url).await?;
 
         Ok(Self(wallet))
@@ -20,7 +21,7 @@ pub async fn make_wallets(
     bitcoind: &Bitcoind<'_>,
     fund_amount_alice: Amount,
     fund_amount_bob: Amount,
-) -> anyhow::Result<(Wallet, Wallet)> {
+) -> Result<(Wallet, Wallet)> {
     let alice = Wallet::new("alice", bitcoind.node_url.clone()).await?;
     let bob = Wallet::new("bob", bitcoind.node_url.clone()).await?;
 
@@ -40,7 +41,7 @@ impl BuildFundingPSBT for Wallet {
         &self,
         output_address: Address,
         output_amount: Amount,
-    ) -> anyhow::Result<PartiallySignedTransaction> {
+    ) -> Result<PartiallySignedTransaction> {
         let psbt = self.0.fund_psbt(output_address, output_amount).await?;
         let as_hex = base64::decode(psbt)?;
 
@@ -55,7 +56,7 @@ impl SignFundingPSBT for Wallet {
     async fn sign_funding_psbt(
         &self,
         psbt: PartiallySignedTransaction,
-    ) -> anyhow::Result<PartiallySignedTransaction> {
+    ) -> Result<PartiallySignedTransaction> {
         let psbt = bitcoin::consensus::serialize(&psbt);
         let as_base64 = base64::encode(psbt);
 
@@ -71,10 +72,7 @@ impl SignFundingPSBT for Wallet {
 
 #[async_trait::async_trait]
 impl BroadcastSignedTransaction for Wallet {
-    async fn broadcast_signed_transaction(
-        &self,
-        transaction: bitcoin::Transaction,
-    ) -> anyhow::Result<()> {
+    async fn broadcast_signed_transaction(&self, transaction: bitcoin::Transaction) -> Result<()> {
         let _txid = self.0.send_raw_transaction(transaction).await?;
 
         // TODO: Instead of guessing how long it will take for the transaction to be
@@ -89,7 +87,7 @@ impl BroadcastSignedTransaction for Wallet {
 
 #[async_trait::async_trait]
 impl NewAddress for Wallet {
-    async fn new_address(&self) -> anyhow::Result<Address> {
+    async fn new_address(&self) -> Result<Address> {
         self.0.new_address().await.map_err(Into::into)
     }
 }

--- a/thor/tests/harness/wallet.rs
+++ b/thor/tests/harness/wallet.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount};
 use bitcoin_harness::{bitcoind_rpc::PsbtBase64, Bitcoind};
 use reqwest::Url;
@@ -35,7 +36,7 @@ pub async fn make_wallets(
     Ok((alice, bob))
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl BuildFundingPSBT for Wallet {
     async fn build_funding_psbt(
         &self,
@@ -51,7 +52,7 @@ impl BuildFundingPSBT for Wallet {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl SignFundingPSBT for Wallet {
     async fn sign_funding_psbt(
         &self,
@@ -70,7 +71,7 @@ impl SignFundingPSBT for Wallet {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl BroadcastSignedTransaction for Wallet {
     async fn broadcast_signed_transaction(&self, transaction: bitcoin::Transaction) -> Result<()> {
         let _txid = self.0.send_raw_transaction(transaction).await?;
@@ -85,7 +86,7 @@ impl BroadcastSignedTransaction for Wallet {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl NewAddress for Wallet {
     async fn new_address(&self) -> Result<Address> {
         self.0.new_address().await.map_err(Into::into)

--- a/thunder/src/db.rs
+++ b/thunder/src/db.rs
@@ -1,5 +1,5 @@
 use crate::{channel, ChannelId};
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use thor::Channel;
 
@@ -12,7 +12,7 @@ struct Database {
 // TODO: Use it
 #[allow(dead_code)]
 impl Database {
-    pub fn new(path: &std::path::Path) -> anyhow::Result<Self> {
+    pub fn new(path: &std::path::Path) -> Result<Self> {
         let path = path
             .to_str()
             .ok_or_else(|| anyhow!("The path is not utf-8 valid: {:?}", path))?;
@@ -21,7 +21,7 @@ impl Database {
         Ok(Database { db })
     }
 
-    pub async fn insert(&self, channel: Channel) -> anyhow::Result<()> {
+    pub async fn insert(&self, channel: Channel) -> Result<()> {
         let channel_id = channel.channel_id();
 
         let stored_channel = self.get_channel(&channel_id);
@@ -47,7 +47,7 @@ impl Database {
         }
     }
 
-    pub fn get_channel(&self, channel_id: &channel::Id) -> anyhow::Result<Channel> {
+    pub fn get_channel(&self, channel_id: &channel::Id) -> Result<Channel> {
         let key = serialize(channel_id)?;
 
         let swap = self
@@ -58,7 +58,7 @@ impl Database {
         deserialize(&swap).context("Could not deserialize channel")
     }
 
-    pub fn all(&self) -> anyhow::Result<Vec<Channel>> {
+    pub fn all(&self) -> Result<Vec<Channel>> {
         self.db
             .iter()
             .filter_map(|item| match item {
@@ -80,14 +80,14 @@ impl Database {
     }
 }
 
-pub fn serialize<T>(t: &T) -> anyhow::Result<Vec<u8>>
+pub fn serialize<T>(t: &T) -> Result<Vec<u8>>
 where
     T: Serialize,
 {
     Ok(serde_cbor::to_vec(t)?)
 }
 
-pub fn deserialize<'a, T>(v: &'a [u8]) -> anyhow::Result<T>
+pub fn deserialize<'a, T>(v: &'a [u8]) -> Result<T>
 where
     T: Deserialize<'a>,
 {

--- a/thunder/src/db.rs
+++ b/thunder/src/db.rs
@@ -1,6 +1,7 @@
 use crate::{channel, ChannelId};
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use thor::Channel;
 
 // TODO: Use it
@@ -12,7 +13,7 @@ struct Database {
 // TODO: Use it
 #[allow(dead_code)]
 impl Database {
-    pub fn new(path: &std::path::Path) -> Result<Self> {
+    pub fn new(path: &Path) -> Result<Self> {
         let path = path
             .to_str()
             .ok_or_else(|| anyhow!("The path is not utf-8 valid: {:?}", path))?;

--- a/thunder/src/main.rs
+++ b/thunder/src/main.rs
@@ -50,6 +50,6 @@ trait ChannelId {
 
 impl ChannelId for Channel {
     fn channel_id(&self) -> channel::Id {
-        channel::Id::new(self.TX_f_txid())
+        channel::Id::new(self.tx_f_txid())
     }
 }


### PR DESCRIPTION
I'm new to the Thor codebase, while looking around to learn whats what I've done a little bit of tidying up.

The first 14 are relatively uncontroversial, please review the docs changes carefully though.

Patch 15 and 16 are somewhat controversial, both have commit messages justifying themselves.

I've intentionally made all these patches small and discreet, if review does not like any those can trivially be dropped.

Patch by Patch: 

- Patch 1 - 9: Adds use statements and removes fully qualified paths for various types
- Patch 10: Makes use statements uniform, adds `crate::` pre-fix
- Patch 11 - 13: Add/improve rustdoc function comments
- Patch 14: Fixes a typo in the type `UnexpecteMessage`
- Patch 15: Lowercases fields of `ShareKeys`
- Patch 16: Lowercases `TX` to `tx`

Thanks