### PR TITLE
Refactor protocol message sending and receiving

### DIFF
--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -473,18 +473,13 @@ impl Channel {
     where
         W: NewAddress + BroadcastSignedTransaction,
     {
-        let current_state = StandardChannelState::from(self.current_state.clone());
+        let state = StandardChannelState::from(self.current_state.clone());
 
-        let commit_transaction =
-            current_state.signed_tx_c(&self.tx_f_body, &self.x_self, &self.X_other)?;
-        wallet
-            .broadcast_signed_transaction(commit_transaction)
-            .await?;
+        let commit = state.signed_tx_c(&self.tx_f_body, &self.x_self, &self.X_other)?;
+        wallet.broadcast_signed_transaction(commit).await?;
 
-        let split_transaction = current_state.signed_tx_s.clone();
-        wallet
-            .broadcast_signed_transaction(split_transaction.clone().into())
-            .await?;
+        let split = state.signed_tx_s;
+        wallet.broadcast_signed_transaction(split.into()).await?;
 
         Ok(())
     }

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -103,42 +103,42 @@ impl Channel {
         let final_address = wallet.new_address().await?;
         let state0 = create::State0::new(balance, time_lock, final_address);
 
-        let msg0_self = state0.next_message();
-        transport.send_message(Message::Create0(msg0_self)).await?;
+        let send = state0.next_message();
+        transport.send_message(Message::Create0(send)).await?;
 
-        let msg0_other = map_err(transport.receive_message().await?.into_create0())?;
-        let state1 = state0.receive(msg0_other, wallet).await?;
+        let recv = map_err(transport.receive_message().await?.into_create0())?;
+        let state1 = state0.receive(recv, wallet).await?;
 
-        let msg1_self = state1.next_message();
-        transport.send_message(Message::Create1(msg1_self)).await?;
+        let send = state1.next_message();
+        transport.send_message(Message::Create1(send)).await?;
 
-        let msg1_other = map_err(transport.receive_message().await?.into_create1())?;
-        let state2 = state1.receive(msg1_other)?;
+        let recv = map_err(transport.receive_message().await?.into_create1())?;
+        let state2 = state1.receive(recv)?;
 
-        let msg2_self = state2.next_message();
-        transport.send_message(Message::Create2(msg2_self)).await?;
+        let send = state2.next_message();
+        transport.send_message(Message::Create2(send)).await?;
 
-        let msg2_other = map_err(transport.receive_message().await?.into_create2())?;
-        let state3 = state2.receive(msg2_other)?;
+        let recv = map_err(transport.receive_message().await?.into_create2())?;
+        let state3 = state2.receive(recv)?;
 
-        let msg3_self = state3.next_message();
-        transport.send_message(Message::Create3(msg3_self)).await?;
+        let send = state3.next_message();
+        transport.send_message(Message::Create3(send)).await?;
 
-        let msg3_other = map_err(transport.receive_message().await?.into_create3())?;
-        let state_4 = state3.receive(msg3_other)?;
+        let recv = map_err(transport.receive_message().await?.into_create3())?;
+        let state_4 = state3.receive(recv)?;
 
-        let msg4_self = state_4.next_message();
-        transport.send_message(Message::Create4(msg4_self)).await?;
+        let send = state_4.next_message();
+        transport.send_message(Message::Create4(send)).await?;
 
-        let msg4_other = map_err(transport.receive_message().await?.into_create4())?;
-        let state5 = state_4.receive(msg4_other)?;
+        let recv = map_err(transport.receive_message().await?.into_create4())?;
+        let state5 = state_4.receive(recv)?;
 
-        let msg5_self = state5.next_message(wallet).await?;
-        transport.send_message(Message::Create5(msg5_self)).await?;
+        let send = state5.next_message(wallet).await?;
+        transport.send_message(Message::Create5(send)).await?;
 
-        let msg5_other = map_err(transport.receive_message().await?.into_create5())?;
+        let recv = map_err(transport.receive_message().await?.into_create5())?;
 
-        let (channel, transaction) = state5.receive(msg5_other, wallet).await?;
+        let (channel, transaction) = state5.receive(recv, wallet).await?;
 
         wallet.broadcast_signed_transaction(transaction).await?;
 

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -103,42 +103,42 @@ impl Channel {
         let final_address = wallet.new_address().await?;
         let state0 = create::State0::new(balance, time_lock, final_address);
 
-        let send = state0.next_message();
+        let send = state0.compose();
         transport.send_message(Message::Create0(send)).await?;
 
         let recv = map_err(transport.receive_message().await?.into_create0())?;
-        let state1 = state0.receive(recv, wallet).await?;
+        let state1 = state0.interpret(recv, wallet).await?;
 
-        let send = state1.next_message();
+        let send = state1.compose();
         transport.send_message(Message::Create1(send)).await?;
 
         let recv = map_err(transport.receive_message().await?.into_create1())?;
-        let state2 = state1.receive(recv)?;
+        let state2 = state1.interpret(recv)?;
 
-        let send = state2.next_message();
+        let send = state2.compose();
         transport.send_message(Message::Create2(send)).await?;
 
         let recv = map_err(transport.receive_message().await?.into_create2())?;
-        let state3 = state2.receive(recv)?;
+        let state3 = state2.interpret(recv)?;
 
-        let send = state3.next_message();
+        let send = state3.compose();
         transport.send_message(Message::Create3(send)).await?;
 
         let recv = map_err(transport.receive_message().await?.into_create3())?;
-        let state_4 = state3.receive(recv)?;
+        let state_4 = state3.interpret(recv)?;
 
-        let send = state_4.next_message();
+        let send = state_4.compose();
         transport.send_message(Message::Create4(send)).await?;
 
         let recv = map_err(transport.receive_message().await?.into_create4())?;
-        let state5 = state_4.receive(recv)?;
+        let state5 = state_4.interpret(recv)?;
 
-        let send = state5.next_message(wallet).await?;
+        let send = state5.compose(wallet).await?;
         transport.send_message(Message::Create5(send)).await?;
 
         let recv = map_err(transport.receive_message().await?.into_create5())?;
 
-        let (channel, transaction) = state5.receive(recv, wallet).await?;
+        let (channel, transaction) = state5.interpret(recv, wallet).await?;
 
         wallet.broadcast_signed_transaction(transaction).await?;
 
@@ -601,30 +601,30 @@ impl Channel {
         )
         .await?;
 
-        let msg0_self = state0.next_message();
+        let msg0_self = state0.compose();
         transport.send_message(Message::Splice0(msg0_self)).await?;
 
         let msg0_other = map_err(transport.receive_message().await?.into_splice0())?;
-        let state1 = state0.receive(msg0_other)?;
+        let state1 = state0.interpret(msg0_other)?;
 
-        let msg1_self = state1.next_message();
+        let msg1_self = state1.compose();
         transport.send_message(Message::Splice1(msg1_self)).await?;
 
         let msg1_other = map_err(transport.receive_message().await?.into_splice1())?;
-        let state2 = state1.receive(msg1_other)?;
+        let state2 = state1.interpret(msg1_other)?;
 
-        let msg2_self = state2.next_message();
+        let msg2_self = state2.compose();
         transport.send_message(Message::Splice2(msg2_self)).await?;
 
         let msg2_other = map_err(transport.receive_message().await?.into_splice2())?;
-        let state3 = state2.receive(msg2_other, wallet).await?;
+        let state3 = state2.interpret(msg2_other, wallet).await?;
 
-        let msg3_self = state3.next_message().await?;
+        let msg3_self = state3.compose().await?;
         transport.send_message(Message::Splice3(msg3_self)).await?;
 
         let msg3_other = map_err(transport.receive_message().await?.into_splice3())?;
 
-        let (channel, transaction) = state3.receive(msg3_other, wallet).await?;
+        let (channel, transaction) = state3.interpret(msg3_other, wallet).await?;
 
         wallet.broadcast_signed_transaction(transaction).await?;
 

--- a/thor/src/protocols/create.rs
+++ b/thor/src/protocols/create.rs
@@ -87,14 +87,14 @@ impl State0 {
         }
     }
 
-    pub fn next_message(&self) -> Message0 {
+    pub fn compose(&self) -> Message0 {
         Message0 {
             X: self.x_self.public(),
             final_address: self.final_address_self.clone(),
         }
     }
 
-    pub async fn receive(
+    pub async fn interpret(
         self,
         Message0 {
             X: X_other,
@@ -131,13 +131,13 @@ pub(crate) struct State1 {
 }
 
 impl State1 {
-    pub fn next_message(&self) -> Message1 {
+    pub fn compose(&self) -> Message1 {
         Message1 {
             input_psbt: self.input_psbt_self.clone(),
         }
     }
 
-    pub fn receive(
+    pub fn interpret(
         self,
         Message1 {
             input_psbt: input_pstb_other,
@@ -180,14 +180,14 @@ pub(crate) struct State2 {
 }
 
 impl State2 {
-    pub fn next_message(&self) -> Message2 {
+    pub fn compose(&self) -> Message2 {
         Message2 {
             R: self.r_self.public(),
             Y: self.y_self.public(),
         }
     }
 
-    pub fn receive(
+    pub fn interpret(
         self,
         Message2 {
             R: R_other,
@@ -256,13 +256,13 @@ pub(crate) struct Party3 {
 }
 
 impl Party3 {
-    pub fn next_message(&self) -> Message3 {
+    pub fn compose(&self) -> Message3 {
         Message3 {
             sig_tx_s: self.sig_tx_s_self.clone(),
         }
     }
 
-    pub fn receive(
+    pub fn interpret(
         mut self,
         Message3 {
             sig_tx_s: sig_tx_s_other,
@@ -315,13 +315,13 @@ pub(crate) struct Party4 {
 }
 
 impl Party4 {
-    pub fn next_message(&self) -> Message4 {
+    pub fn compose(&self) -> Message4 {
         Message4 {
             encsig_tx_c: self.encsig_tx_c_self.clone(),
         }
     }
 
-    pub fn receive(
+    pub fn interpret(
         self,
         Message4 {
             encsig_tx_c: encsig_tx_c_other,
@@ -380,7 +380,7 @@ pub trait SignFundingPSBT {
 }
 
 impl Party5 {
-    pub async fn next_message(&self, wallet: &impl SignFundingPSBT) -> Result<Message5> {
+    pub async fn compose(&self, wallet: &impl SignFundingPSBT) -> Result<Message5> {
         let tx_f_signed_once = wallet
             .sign_funding_psbt(self.tx_f.clone().into_psbt()?)
             .await?;
@@ -389,7 +389,7 @@ impl Party5 {
     }
 
     /// Returns the Channel and the transaction to broadcast.
-    pub async fn receive(
+    pub async fn interpret(
         self,
         Message5 { tx_f_signed_once }: Message5,
         wallet: &impl SignFundingPSBT,

--- a/thor/src/protocols/splice.rs
+++ b/thor/src/protocols/splice.rs
@@ -134,7 +134,7 @@ impl State0 {
         })
     }
 
-    pub fn next_message(&self) -> Message0 {
+    pub fn compose(&self) -> Message0 {
         Message0 {
             R: self.r_self.public(),
             Y: self.y_self.public(),
@@ -142,7 +142,7 @@ impl State0 {
         }
     }
 
-    pub fn receive(
+    pub fn interpret(
         self,
         Message0 {
             R: R_other,
@@ -273,13 +273,13 @@ pub(crate) struct State1 {
 }
 
 impl State1 {
-    pub fn next_message(&self) -> Message1 {
+    pub fn compose(&self) -> Message1 {
         Message1 {
             sig_tx_s: self.sig_tx_s_self.clone(),
         }
     }
 
-    pub fn receive(
+    pub fn interpret(
         mut self,
         Message1 {
             sig_tx_s: sig_tx_s_other,
@@ -336,13 +336,13 @@ pub(crate) struct State2 {
 }
 
 impl State2 {
-    pub fn next_message(&self) -> Message2 {
+    pub fn compose(&self) -> Message2 {
         Message2 {
             encsig_tx_c: self.encsig_tx_c_self.clone(),
         }
     }
 
-    pub async fn receive(
+    pub async fn interpret(
         self,
         Message2 {
             encsig_tx_c: encsig_tx_c_other,
@@ -411,7 +411,7 @@ pub(crate) struct State3 {
 }
 
 impl State3 {
-    pub async fn next_message(&self) -> Result<Message3> {
+    pub async fn compose(&self) -> Result<Message3> {
         Ok(Message3 {
             splice_transaction_signature: self.splice_transaction_signature.clone(),
             signed_splice_transaction: self.signed_splice_transaction.clone(),
@@ -419,7 +419,7 @@ impl State3 {
     }
 
     /// Returns the Channel and the transaction to broadcast.
-    pub async fn receive(
+    pub async fn interpret(
         self,
         Message3 {
             splice_transaction_signature: splice_transaction_signature_other,


### PR DESCRIPTION
This PR refactors the logic around sending and receiving messages. Currently we use unique identifiers for all the various states and messages.

By adding `From` and `TryFrom` impls for all the `Message` variants to/from their inner types we can simplify the functions `create(), close(), update(), splice()`. Each step (i.e., send/receive and interpret new state) is now done with the same few lines of code
```
        transport.send_message(state.compose().into()).await?;
        let response = transport.receive_message().await?.try_into()?;
        let state = state.interpret(response, wallet).await?;
```

As needed due to return types the `.await` and `?` may vary. Also the return type of the call to `interpret` varies. 

`force_close()` gets an unrelated minor refactoring as well.