### PR TITLE
Make serde cfg_attr less noisy

### DIFF
--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -48,6 +48,9 @@ use futures::{future::Either, pin_mut, Future};
 use genawaiter::sync::Gen;
 use std::convert::{TryFrom, TryInto};
 
+#[cfg(feature = "serde")]
+use bitcoin::util::amount::serde::as_sat;
+
 // TODO: We should handle fees dynamically
 
 // TODO: Have it as an `Amount` instead
@@ -666,15 +669,9 @@ impl RevokedState {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Balance {
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     pub ours: Amount,
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     pub theirs: Amount,
 }
 
@@ -683,10 +680,7 @@ pub struct Balance {
 pub enum SplitOutput {
     Ptlc(Ptlc),
     Balance {
-        #[cfg_attr(
-            feature = "serde",
-            serde(with = "bitcoin::util::amount::serde::as_sat")
-        )]
+        #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
         amount: Amount,
         address: Address,
     },
@@ -695,10 +689,7 @@ pub enum SplitOutput {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct Ptlc {
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     amount: Amount,
     X_funder: OwnershipPublicKey,
     X_redeemer: OwnershipPublicKey,

--- a/thor/src/protocols/splice.rs
+++ b/thor/src/protocols/splice.rs
@@ -9,6 +9,7 @@ use crate::{
     Balance, BuildFundingPsbt, Channel, ChannelState, SignFundingPsbt, SplitOutput,
     StandardChannelState, TX_FEE,
 };
+
 use anyhow::{Context, Result};
 use bitcoin::{
     consensus::serialize, util::psbt::PartiallySignedTransaction, Address, Amount, Transaction,
@@ -17,6 +18,11 @@ use bitcoin::{
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
 use miniscript::Descriptor;
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "serde")]
+use crate::serde::partially_signed_transaction as pst;
+#[cfg(feature = "serde")]
+use bitcoin::util::amount::serde::as_sat;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
@@ -69,15 +75,9 @@ pub(crate) struct State0 {
 #[derive(Clone, Debug)]
 pub(crate) enum Splice {
     In {
-        #[cfg_attr(
-            feature = "serde",
-            serde(with = "bitcoin::util::amount::serde::as_sat")
-        )]
+        #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
         amount: Amount,
-        #[cfg_attr(
-            feature = "serde",
-            serde(with = "crate::serde::partially_signed_transaction")
-        )]
+        #[cfg_attr(feature = "serde", serde(with = "pst"))]
         input_psbt: PartiallySignedTransaction,
     },
     Out(TxOut),

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -11,7 +11,7 @@ use bitcoin::{
     consensus::encode::serialize,
     hashes::{hash160, Hash},
     secp256k1,
-    util::{bip143::SighashComponents, psbt::PartiallySignedTransaction},
+    util::{amount::serde::as_sat, bip143::SighashComponents, psbt::PartiallySignedTransaction},
     Address, Amount, Network, OutPoint, Script, SigHash, Transaction, TxIn, TxOut, Txid,
 };
 use ecdsa_fun::{
@@ -58,10 +58,7 @@ impl FundOutput {
 pub(crate) struct FundingTransaction {
     inner: Transaction,
     fund_output_descriptor: Descriptor<bitcoin::PublicKey>,
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     fund_output_amount: Amount,
 }
 
@@ -169,10 +166,7 @@ pub(crate) struct CommitTransaction {
     output_descriptor: Descriptor<bitcoin::PublicKey>,
     time_lock: u32,
     digest: SigHash,
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     fee: Amount,
 }
 
@@ -952,15 +946,9 @@ pub(crate) fn balance(
 pub(crate) struct SpliceTransaction {
     inner: Transaction,
     fund_output_descriptor: Descriptor<bitcoin::PublicKey>,
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     amount_0: Amount,
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     amount_1: Amount,
 }
 


### PR DESCRIPTION
We currently have a bunch of places in the codebase that use the `cfg_attr` to
control serialization. We use the fully qualified path of `as_sat()` which often
makes the attribute format over 4 lines. If we import the `as_sat` function then
we can remove the fully qualified path and reduce the attribute to a single
line. This makes the code way less noisy and much more gentle on the eyes of the
reader.