### PR TITLE
Add two step macros

### DIFF
--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -425,9 +425,9 @@ impl Channel {
         T: SendMessage + ReceiveMessage,
         W: NewAddress + BroadcastSignedTransaction,
     {
-        let state = close::State0::new(&self);
+        let state = close::State0::new(&self)?;
 
-        transport.send_message(state.compose()?.into()).await?;
+        transport.send_message(state.compose().into()).await?;
         let response = transport.receive_message().await?.try_into()?;
         let close_transaction = state.interpret(response)?;
 

--- a/thor/src/protocols/close.rs
+++ b/thor/src/protocols/close.rs
@@ -16,6 +16,7 @@ pub(crate) struct State0 {
     final_address_self: Address,
     final_address_other: Address,
     balance: Balance,
+    close_tx: CloseTransaction,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -25,27 +26,31 @@ pub struct Message0 {
 }
 
 impl State0 {
-    pub(crate) fn new(channel: &Channel) -> Self {
-        Self {
+    pub(crate) fn new(channel: &Channel) -> Result<Self> {
+        let Balance { ours, theirs } = channel.balance();
+        let addr_ours = channel.final_address_self.clone();
+        let addr_theirs = channel.final_address_other.clone();
+        let tx_f = channel.tx_f_body.clone();
+
+        let tx = CloseTransaction::new(&tx_f, [(ours, addr_ours), (theirs, addr_theirs)])?;
+
+        Ok(Self {
             x_self: channel.x_self.clone(),
             X_other: channel.X_other.clone(),
-            tx_f: channel.tx_f_body.clone(),
+            tx_f,
             balance: channel.balance(),
             final_address_self: channel.final_address_self.clone(),
             final_address_other: channel.final_address_other.clone(),
-        }
+            close_tx: tx,
+        })
     }
 
-    pub(crate) fn compose(&self) -> Result<Message0> {
-        let close_transaction = CloseTransaction::new(&self.tx_f, [
-            (self.balance.ours, self.final_address_self.clone()),
-            (self.balance.theirs, self.final_address_other.clone()),
-        ])?;
-        let sig_close_transaction = close_transaction.sign(&self.x_self);
+    pub(crate) fn compose(&self) -> Message0 {
+        let sig_close_transaction = self.close_tx.sign(&self.x_self);
 
-        Ok(Message0 {
+        Message0 {
             sig_close_transaction,
-        })
+        }
     }
 
     pub(crate) fn interpret(
@@ -54,10 +59,7 @@ impl State0 {
             sig_close_transaction: sig_close_transaction_other,
         }: Message0,
     ) -> Result<Transaction> {
-        let close_transaction = CloseTransaction::new(&self.tx_f, [
-            (self.balance.ours, self.final_address_self),
-            (self.balance.theirs, self.final_address_other),
-        ])?;
+        let close_transaction = self.close_tx;
 
         close_transaction
             .verify_sig(self.X_other.clone(), &sig_close_transaction_other)

--- a/thor/src/protocols/splice.rs
+++ b/thor/src/protocols/splice.rs
@@ -441,11 +441,11 @@ pub(crate) struct State3 {
 }
 
 impl State3 {
-    pub async fn compose(&self) -> Result<Message3> {
-        Ok(Message3 {
+    pub fn compose(&self) -> Message3 {
+        Message3 {
             sig_TX_splice_TX_f_input: self.sig_TX_splice_TX_f_input.clone(),
             signed_TX_splice_psbt_input: self.signed_TX_splice_psbt_self_input.clone(),
-        })
+        }
     }
 
     /// Returns the Channel and the transaction to broadcast.


### PR DESCRIPTION
This one is hot! Add macros `step` and `step_wallet` that combine the three steps, send message, receive message, interpret message.

Unfortunately in order to handle the transport `&mut T: transport` I had to pass it into the macros and return it. This leads to code like this
```
let (transport, state) = step!(transport, state)
```

It would be nicer to be able to write 
```
let state = step!(transport, state)
```

Any ideas please?
