### PR TITLE
Use lowercase for acronym PSBT

### DIFF
--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -24,7 +24,7 @@ mod transaction;
 
 pub use ::bitcoin;
 pub use keys::{PtlcPoint, PtlcSecret};
-pub use protocols::create::{BuildFundingPSBT, SignFundingPSBT};
+pub use protocols::create::{BuildFundingPsbt, SignFundingPsbt};
 
 use crate::{
     keys::{
@@ -99,7 +99,7 @@ impl Channel {
     ) -> Result<Self>
     where
         T: SendMessage + ReceiveMessage,
-        W: BuildFundingPSBT + SignFundingPSBT + BroadcastSignedTransaction + NewAddress,
+        W: BuildFundingPsbt + SignFundingPsbt + BroadcastSignedTransaction + NewAddress,
     {
         let final_address = wallet.new_address().await?;
         let state = create::State0::new(balance, time_lock, final_address);
@@ -539,7 +539,7 @@ impl Channel {
         splice_in: Option<Amount>,
     ) -> Result<Self>
     where
-        W: BroadcastSignedTransaction + BuildFundingPSBT + SignFundingPSBT,
+        W: BroadcastSignedTransaction + BuildFundingPsbt + SignFundingPsbt,
         T: SendMessage + ReceiveMessage,
     {
         // Re-use timelock, final addresses, balance, ownership keys

--- a/thor/src/protocols/create.rs
+++ b/thor/src/protocols/create.rs
@@ -67,7 +67,7 @@ pub(crate) struct State0 {
 }
 
 #[async_trait]
-pub trait BuildFundingPSBT {
+pub trait BuildFundingPsbt {
     async fn build_funding_psbt(
         &self,
         output_address: Address,
@@ -100,7 +100,7 @@ impl State0 {
             X: X_other,
             final_address: final_address_other,
         }: Message0,
-        wallet: &impl BuildFundingPSBT,
+        wallet: &impl BuildFundingPsbt,
     ) -> Result<State1> {
         let fund_output = FundOutput::new([self.x_self.public(), X_other.clone()]);
         let input_psbt_self = wallet
@@ -372,7 +372,7 @@ pub(crate) struct Party5 {
 
 /// Sign one of the inputs of the `FundingTransaction`.
 #[async_trait]
-pub trait SignFundingPSBT {
+pub trait SignFundingPsbt {
     async fn sign_funding_psbt(
         &self,
         psbt: PartiallySignedTransaction,
@@ -380,7 +380,7 @@ pub trait SignFundingPSBT {
 }
 
 impl Party5 {
-    pub async fn compose(&self, wallet: &impl SignFundingPSBT) -> Result<Message5> {
+    pub async fn compose(&self, wallet: &impl SignFundingPsbt) -> Result<Message5> {
         let tx_f_signed_once = wallet
             .sign_funding_psbt(self.tx_f.clone().into_psbt()?)
             .await?;
@@ -392,7 +392,7 @@ impl Party5 {
     pub async fn interpret(
         self,
         Message5 { tx_f_signed_once }: Message5,
-        wallet: &impl SignFundingPSBT,
+        wallet: &impl SignFundingPsbt,
     ) -> Result<(Channel, Transaction)> {
         let signed_tx_f = wallet.sign_funding_psbt(tx_f_signed_once).await?;
         let signed_tx_f = signed_tx_f.extract_tx();

--- a/thor/src/protocols/splice.rs
+++ b/thor/src/protocols/splice.rs
@@ -6,7 +6,7 @@ use crate::{
     transaction::{
         CommitTransaction, FundOutput, FundingTransaction, SpliceTransaction, SplitTransaction,
     },
-    Balance, BuildFundingPSBT, Channel, ChannelState, SignFundingPSBT, SplitOutput,
+    Balance, BuildFundingPsbt, Channel, ChannelState, SignFundingPsbt, SplitOutput,
     StandardChannelState,
 };
 use anyhow::{Context, Result};
@@ -82,7 +82,7 @@ pub struct SpliceIn {
 }
 
 #[async_trait]
-pub trait BuildSplicePSBT {
+pub trait BuildSplicePsbt {
     async fn build_funding_psbt(
         &self,
         output_address: Address,
@@ -104,7 +104,7 @@ impl State0 {
         wallet: &W,
     ) -> Result<State0>
     where
-        W: BuildFundingPSBT,
+        W: BuildFundingPsbt,
     {
         let splice_in_self = match splice_in {
             Some(amount) => {
@@ -174,7 +174,7 @@ impl State0 {
             their_balance += splice_in.amount;
         }
 
-        // Sort the PSBT inputs based on the ascending lexicographical order of
+        // Sort the Psbt inputs based on the ascending lexicographical order of
         // bytes of their consensus serialization. Both parties _must_ do this so that
         // they compute the same splice transaction.
         splice_in_inputs.sort_by(|a, b| {
@@ -198,7 +198,7 @@ impl State0 {
             (self.X_other.clone(), balance.theirs),
         ])?;
 
-        // TODO: Clean-up the signature/PSBT mix (if possible)
+        // TODO: Clean-up the signature/Psbt mix (if possible)
 
         // Signed to spend tx_f
         let sig_tx_f = tx_f.sign_once(self.x_self.clone(), &self.previous_tx_f);
@@ -347,7 +347,7 @@ impl State2 {
         Message2 {
             encsig_tx_c: encsig_tx_c_other,
         }: Message2,
-        wallet: &impl SignFundingPSBT,
+        wallet: &impl SignFundingPsbt,
     ) -> Result<State3> {
         self.tx_c
             .verify_encsig(
@@ -425,7 +425,7 @@ impl State3 {
             splice_transaction_signature: splice_transaction_signature_other,
             signed_splice_transaction: signed_splice_transaction_other,
         }: Message3,
-        wallet: &impl SignFundingPSBT,
+        wallet: &impl SignFundingPsbt,
     ) -> Result<(Channel, Transaction)> {
         // TODO: Check that the received splice transaction is the same than we expect
         // If the other party sent a splice-in signed tx_f, use it, otherwise, use our

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -75,7 +75,7 @@ impl FundingTransaction {
         }
 
         // Sort the tuples of arguments based on the ascending lexicographical order of
-        // bytes of each consensus encoded PSBT. Both parties _must_ do this so that
+        // bytes of each consensus encoded Psbt. Both parties _must_ do this so that
         // they compute the same funding transaction
         input_psbts.sort_by(|a, b| {
             serialize(a)
@@ -979,7 +979,7 @@ impl SpliceTransaction {
         }
 
         // Sort the tuples of arguments based on the ascending lexicographical order of
-        // bytes of each consensus encoded PSBT. Both parties _must_ do this so that
+        // bytes of each consensus encoded Psbt. Both parties _must_ do this so that
         // they compute the same funding transaction
         inputs.sort_by(|a, b| {
             serialize(a)

--- a/thor/tests/harness/wallet.rs
+++ b/thor/tests/harness/wallet.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Amount};
 use bitcoin_harness::{bitcoind_rpc::PsbtBase64, Bitcoind};
 use reqwest::Url;
-use thor::{BroadcastSignedTransaction, BuildFundingPSBT, NewAddress, SignFundingPSBT};
+use thor::{BroadcastSignedTransaction, BuildFundingPsbt, NewAddress, SignFundingPsbt};
 
 pub struct Wallet(pub bitcoin_harness::Wallet);
 
@@ -37,7 +37,7 @@ pub async fn make_wallets(
 }
 
 #[async_trait]
-impl BuildFundingPSBT for Wallet {
+impl BuildFundingPsbt for Wallet {
     async fn build_funding_psbt(
         &self,
         output_address: Address,
@@ -53,7 +53,7 @@ impl BuildFundingPSBT for Wallet {
 }
 
 #[async_trait]
-impl SignFundingPSBT for Wallet {
+impl SignFundingPsbt for Wallet {
     async fn sign_funding_psbt(
         &self,
         psbt: PartiallySignedTransaction,


### PR DESCRIPTION
We should use `Psbt` instead of `PSBT` in identifiers in line with Rust naming
conventions:

	In CamelCase, acronyms count as one word: use Uuid rather than UUID. In
	snake_case, acronyms are lower-cased: is_xid_start.

ref: https://doc.rust-lang.org/1.0.0/style/style/naming/README.html