### PR TITLE
Minor cleanup

### DIFF
--- a/thor/src/keys.rs
+++ b/thor/src/keys.rs
@@ -307,7 +307,7 @@ fn public_key(secret_key: &Scalar) -> Point {
 fn sign(secret_key: &Scalar, digest: SigHash) -> Signature {
     let ecdsa = ECDSA::<Deterministic<Sha256>>::default();
 
-    ecdsa.sign(&secret_key, &digest.into_inner())
+    ecdsa.sign(secret_key, &digest.into_inner())
 }
 
 #[cfg(test)]

--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -620,7 +620,7 @@ impl StandardChannelState {
         x_self: &OwnershipKeyPair,
         X_other: &OwnershipPublicKey,
     ) -> Result<Transaction> {
-        let sig_self = self.tx_c.sign_once(x_self);
+        let sig_self = self.tx_c.sign(x_self);
         let sig_other = decrypt(self.y_self.clone().into(), self.encsig_tx_c_other.clone());
 
         let signed_tx_c = self.tx_c.clone().add_signatures(
@@ -637,7 +637,7 @@ impl StandardChannelState {
     }
 
     pub fn encsign_tx_c_self(&self, x_self: &OwnershipKeyPair) -> EncryptedSignature {
-        self.tx_c.encsign_once(x_self, self.Y_other.clone())
+        self.tx_c.encsign(x_self, self.Y_other.clone())
     }
 }
 

--- a/thor/src/protocols/close.rs
+++ b/thor/src/protocols/close.rs
@@ -41,7 +41,7 @@ impl State0 {
             (self.balance.ours, self.final_address_self.clone()),
             (self.balance.theirs, self.final_address_other.clone()),
         ])?;
-        let sig_close_transaction = close_transaction.sign_once(&self.x_self);
+        let sig_close_transaction = close_transaction.sign(&self.x_self);
 
         Ok(Message0 {
             sig_close_transaction,
@@ -63,7 +63,7 @@ impl State0 {
             .verify_sig(self.X_other.clone(), &sig_close_transaction_other)
             .context("failed to verify close transaction signature sent by counterparty")?;
 
-        let sig_close_transaction_self = close_transaction.sign_once(&self.x_self);
+        let sig_close_transaction_self = close_transaction.sign(&self.x_self);
         let close_transaction = close_transaction.add_signatures(
             (self.x_self.public(), sig_close_transaction_self),
             (self.X_other, sig_close_transaction_other),

--- a/thor/src/protocols/create.rs
+++ b/thor/src/protocols/create.rs
@@ -218,7 +218,7 @@ impl State2 {
             },
         ];
         let tx_s = SplitTransaction::new(&tx_c, split_outputs.clone())?;
-        let sig_tx_s_self = tx_s.sign_once(&self.x_self);
+        let sig_tx_s_self = tx_s.sign(&self.x_self);
 
         Ok(Party3 {
             x_self: self.x_self,
@@ -277,7 +277,7 @@ impl Party3 {
             (self.X_other.clone(), sig_tx_s_other),
         )?;
 
-        let encsig_tx_c_self = self.tx_c.encsign_once(&self.x_self, self.Y_other.clone());
+        let encsig_tx_c_self = self.tx_c.encsign(&self.x_self, self.Y_other.clone());
 
         Ok(Party4 {
             x_self: self.x_self,

--- a/thor/src/protocols/splice.rs
+++ b/thor/src/protocols/splice.rs
@@ -231,7 +231,7 @@ impl State0 {
 
         // Signed to spend TX_f
         let sig_TX_splice_TX_f_input =
-            splice_transaction.sign_once(self.x_self.clone(), &self.previous_tx_f);
+            splice_transaction.sign(self.x_self.clone(), &self.previous_tx_f);
 
         let tx_c = CommitTransaction::new(
             &splice_transaction.clone().into(),
@@ -245,7 +245,7 @@ impl State0 {
             ],
             self.time_lock,
         )?;
-        let encsig_tx_c_self = tx_c.encsign_once(&self.x_self, Y_other.clone());
+        let encsig_tx_c_self = tx_c.encsign(&self.x_self, Y_other.clone());
 
         let tx_s = SplitTransaction::new(&tx_c, vec![
             SplitOutput::Balance {
@@ -257,7 +257,7 @@ impl State0 {
                 address: self.final_address_other.clone(),
             },
         ])?;
-        let sig_tx_s_self = tx_s.sign_once(&self.x_self);
+        let sig_tx_s_self = tx_s.sign(&self.x_self);
 
         Ok(State1 {
             x_self: self.x_self,

--- a/thor/src/protocols/splice.rs
+++ b/thor/src/protocols/splice.rs
@@ -230,7 +230,7 @@ impl State0 {
         ])?;
 
         // Signed to spend TX_f
-        let sig_tx_splice_tx_f_input =
+        let sig_TX_splice_TX_f_input =
             splice_transaction.sign_once(self.x_self.clone(), &self.previous_tx_f);
 
         let tx_c = CommitTransaction::new(

--- a/thor/src/protocols/update.rs
+++ b/thor/src/protocols/update.rs
@@ -104,10 +104,10 @@ impl State0 {
             ],
             self.time_lock,
         )?;
-        let encsig_tx_c_self = tx_c.encsign_once(&self.x_self, Y_other.clone());
+        let encsig_tx_c_self = tx_c.encsign(&self.x_self, Y_other.clone());
 
         let tx_s = SplitTransaction::new(&tx_c, self.new_split_outputs.clone())?;
-        let sig_tx_s_self = tx_s.sign_once(&self.x_self);
+        let sig_tx_s_self = tx_s.sign(&self.x_self);
 
         let state = State1 {
             x_self: self.x_self.clone(),
@@ -197,11 +197,11 @@ impl State1PtlcFunder {
     pub fn new(state: State1, ptlc: Ptlc) -> Result<Self> {
         let tx_ptlc_redeem =
             RedeemTransaction::new(&state.tx_s, ptlc.clone(), state.final_address_other.clone())?;
-        let encsig_tx_ptlc_redeem_funder = tx_ptlc_redeem.encsign_once(&state.x_self, ptlc.point());
+        let encsig_tx_ptlc_redeem_funder = tx_ptlc_redeem.encsign(&state.x_self, ptlc.point());
 
         let tx_ptlc_refund =
             RefundTransaction::new(&state.tx_s, ptlc.clone(), state.final_address_self.clone())?;
-        let sig_tx_ptlc_refund_funder = tx_ptlc_refund.sign_once(&state.x_self);
+        let sig_tx_ptlc_refund_funder = tx_ptlc_refund.sign(&state.x_self);
 
         Ok(Self {
             inner: state,
@@ -268,11 +268,11 @@ impl State1PtlcRedeemer {
     pub fn new(state: State1, ptlc: Ptlc) -> Result<Self> {
         let tx_ptlc_redeem =
             RedeemTransaction::new(&state.tx_s, ptlc.clone(), state.final_address_self.clone())?;
-        let sig_tx_ptlc_redeem_redeemer = tx_ptlc_redeem.sign_once(&state.x_self);
+        let sig_tx_ptlc_redeem_redeemer = tx_ptlc_redeem.sign(&state.x_self);
 
         let tx_ptlc_refund =
             RefundTransaction::new(&state.tx_s, ptlc.clone(), state.final_address_other.clone())?;
-        let sig_tx_ptlc_refund_redeemer = tx_ptlc_refund.sign_once(&state.x_self);
+        let sig_tx_ptlc_refund_redeemer = tx_ptlc_refund.sign(&state.x_self);
 
         Ok(Self {
             inner: state,

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -207,7 +207,7 @@ impl CommitTransaction {
         })
     }
 
-    pub fn encsign_once(
+    pub fn encsign(
         &self,
         x_self: &OwnershipKeyPair,
         Y_other: PublishingPublicKey,
@@ -215,7 +215,7 @@ impl CommitTransaction {
         x_self.encsign(Y_other.into(), self.digest)
     }
 
-    pub fn sign_once(&self, x_self: &OwnershipKeyPair) -> Signature {
+    pub fn sign(&self, x_self: &OwnershipKeyPair) -> Signature {
         x_self.sign(self.digest)
     }
 
@@ -567,7 +567,7 @@ impl SplitTransaction {
         Ok((input_0_fees, input_1_fees))
     }
 
-    pub fn sign_once(&self, x_self: &OwnershipKeyPair) -> Signature {
+    pub fn sign(&self, x_self: &OwnershipKeyPair) -> Signature {
         x_self.sign(self.digest)
     }
 
@@ -895,7 +895,7 @@ impl CloseTransaction {
         Ok(close_transaction)
     }
 
-    pub fn sign_once(&self, x_self: &OwnershipKeyPair) -> Signature {
+    pub fn sign(&self, x_self: &OwnershipKeyPair) -> Signature {
         x_self.sign(self.digest)
     }
 }
@@ -1045,11 +1045,7 @@ impl SpliceTransaction {
         )
     }
 
-    pub fn sign_once(
-        &self,
-        x_self: OwnershipKeyPair,
-        previous_tx_f: &FundingTransaction,
-    ) -> Signature {
+    pub fn sign(&self, x_self: OwnershipKeyPair, previous_tx_f: &FundingTransaction) -> Signature {
         let digest = self.compute_digest(previous_tx_f);
         x_self.sign(digest)
     }

--- a/thor/src/transaction/ptlc.rs
+++ b/thor/src/transaction/ptlc.rs
@@ -35,11 +35,11 @@ impl RedeemTransaction {
         })
     }
 
-    pub fn sign_once(&self, x_self: &OwnershipKeyPair) -> Signature {
+    pub fn sign(&self, x_self: &OwnershipKeyPair) -> Signature {
         x_self.sign(self.digest)
     }
 
-    pub fn encsign_once(&self, x_self: &OwnershipKeyPair, point: PtlcPoint) -> EncryptedSignature {
+    pub fn encsign(&self, x_self: &OwnershipKeyPair, point: PtlcPoint) -> EncryptedSignature {
         x_self.encsign(point.into(), self.digest)
     }
 
@@ -107,7 +107,7 @@ impl RefundTransaction {
         })
     }
 
-    pub fn sign_once(&self, x_self: &OwnershipKeyPair) -> Signature {
+    pub fn sign(&self, x_self: &OwnershipKeyPair) -> Signature {
         x_self.sign(self.digest)
     }
 


### PR DESCRIPTION
A few last minor cleanups to the `thor` lib.

- Patch 1: Removes an unnecessary `&`, cannot workout why this was not caught by rustc
- patch 2: Removes duplicate code by adding helper methods for creating split `Balance`s
- Patch 3: Drops the `_once` suffix off sign methods.