### PR TITLE
Use uppercase acronym PSBT in comments

### DIFF
--- a/thor/src/protocols/splice.rs
+++ b/thor/src/protocols/splice.rs
@@ -196,7 +196,7 @@ impl State0 {
             Splice::None => (),
         }
 
-        // Sort the Psbt inputs based on the ascending lexicographical order of
+        // Sort the PSBT inputs based on the ascending lexicographical order of
         // bytes of their consensus serialization. Both parties _must_ do this so that
         // they compute the same splice transaction.
         splice_in_inputs.sort_by(|a, b| {
@@ -230,7 +230,7 @@ impl State0 {
         ])?;
 
         // Signed to spend TX_f
-        let sig_TX_splice_TX_f_input =
+        let sig_tx_splice_tx_f_input =
             splice_transaction.sign_once(self.x_self.clone(), &self.previous_tx_f);
 
         let tx_c = CommitTransaction::new(

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -75,7 +75,7 @@ impl FundingTransaction {
         }
 
         // Sort the tuples of arguments based on the ascending lexicographical order of
-        // bytes of each consensus encoded Psbt. Both parties _must_ do this so that
+        // bytes of each consensus encoded PSBT. Both parties _must_ do this so that
         // they compute the same funding transaction
         input_psbts.sort_by(|a, b| {
             serialize(a)
@@ -975,7 +975,7 @@ impl SpliceTransaction {
         }
 
         // Sort the tuples of arguments based on the ascending lexicographical order of
-        // bytes of each consensus encoded Psbt. Both parties _must_ do this so that
+        // bytes of each consensus encoded PSBT. Both parties _must_ do this so that
         // they compute the same funding transaction
         inputs.sort_by(|a, b| {
             serialize(a)


### PR DESCRIPTION
Bad Tobin - no biscuit.

Recently we change identifiers to use `Psbt` instead of `PSBT`. During this work
we accidentally changed the acronym form in comments also, this is incorrect. In
comments we should use 'PSBT'.