### PR TITLE
Minor tweaks to handling of input arrays

### DIFF
--- a/thor/src/lib.rs
+++ b/thor/src/lib.rs
@@ -48,6 +48,9 @@ use futures::{future::Either, pin_mut, Future};
 use genawaiter::sync::Gen;
 use std::convert::{TryFrom, TryInto};
 
+#[cfg(feature = "serde")]
+use bitcoin::util::amount::serde::as_sat;
+
 // TODO: We should handle fees dynamically
 
 // TODO: Have it as an `Amount` instead
@@ -666,15 +669,9 @@ impl RevokedState {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Balance {
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     pub ours: Amount,
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     pub theirs: Amount,
 }
 
@@ -683,10 +680,7 @@ pub struct Balance {
 pub enum SplitOutput {
     Ptlc(Ptlc),
     Balance {
-        #[cfg_attr(
-            feature = "serde",
-            serde(with = "bitcoin::util::amount::serde::as_sat")
-        )]
+        #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
         amount: Amount,
         address: Address,
     },
@@ -695,10 +689,7 @@ pub enum SplitOutput {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct Ptlc {
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     amount: Amount,
     X_funder: OwnershipPublicKey,
     X_redeemer: OwnershipPublicKey,

--- a/thor/src/protocols/create.rs
+++ b/thor/src/protocols/create.rs
@@ -143,7 +143,7 @@ impl State1 {
             input_psbt: input_pstb_other,
         }: Message1,
     ) -> Result<State2> {
-        let tx_f = FundingTransaction::new(vec![self.input_psbt_self.clone(), input_pstb_other], [
+        let tx_f = FundingTransaction::new([self.input_psbt_self.clone(), input_pstb_other], [
             (self.x_self.public(), self.balance.ours),
             (self.X_other.clone(), self.balance.theirs),
         ])

--- a/thor/src/protocols/splice.rs
+++ b/thor/src/protocols/splice.rs
@@ -9,6 +9,7 @@ use crate::{
     Balance, BuildFundingPsbt, Channel, ChannelState, SignFundingPsbt, SplitOutput,
     StandardChannelState, TX_FEE,
 };
+
 use anyhow::{Context, Result};
 use bitcoin::{
     consensus::serialize, util::psbt::PartiallySignedTransaction, Address, Amount, Transaction,
@@ -17,6 +18,11 @@ use bitcoin::{
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
 use miniscript::Descriptor;
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "serde")]
+use crate::serde::partially_signed_transaction as pst;
+#[cfg(feature = "serde")]
+use bitcoin::util::amount::serde::as_sat;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
@@ -69,15 +75,9 @@ pub(crate) struct State0 {
 #[derive(Clone, Debug)]
 pub(crate) enum Splice {
     In {
-        #[cfg_attr(
-            feature = "serde",
-            serde(with = "bitcoin::util::amount::serde::as_sat")
-        )]
+        #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
         amount: Amount,
-        #[cfg_attr(
-            feature = "serde",
-            serde(with = "crate::serde::partially_signed_transaction")
-        )]
+        #[cfg_attr(feature = "serde", serde(with = "pst"))]
         input_psbt: PartiallySignedTransaction,
     },
     Out(TxOut),

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -37,9 +37,7 @@ impl FundOutput {
         // Both parties _must_ insert the ownership public keys into the script in
         // ascending lexicographical order of bytes
         Xs.sort_by(|a, b| a.partial_cmp(b).expect("comparison is possible"));
-        let [X_0, X_1] = Xs;
-
-        let descriptor = build_shared_output_descriptor(X_0, X_1);
+        let descriptor = build_shared_output_descriptor(Xs[0].clone(), Xs[1].clone());
 
         Self(descriptor)
     }
@@ -449,8 +447,7 @@ impl SplitTransaction {
                     // ascending lexicographical order of bytes
                     let mut Xs = [X_funder, X_redeemer];
                     Xs.sort_by(|a, b| a.partial_cmp(b).expect("comparison is possible"));
-                    let [X_0, X_1] = Xs;
-                    let descriptor = build_shared_output_descriptor(X_0.clone(), X_1.clone());
+                    let descriptor = build_shared_output_descriptor(Xs[0].clone(), Xs[1].clone());
 
                     TxOut {
                         value: amount.as_sat(),

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -64,13 +64,10 @@ pub(crate) struct FundingTransaction {
 
 impl FundingTransaction {
     pub fn new(
-        mut input_psbts: Vec<PartiallySignedTransaction>,
+        input_psbts: [PartiallySignedTransaction; 2],
         channel_balance: [(OwnershipPublicKey, Amount); 2],
     ) -> Result<Self> {
-        if input_psbts.is_empty() {
-            bail!("Cannot build a transaction without inputs")
-        }
-
+        let mut input_psbts = input_psbts.to_vec();
         // Sort the tuples of arguments based on the ascending lexicographical order of
         // bytes of each consensus encoded PSBT. Both parties _must_ do this so that
         // they compute the same funding transaction

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -11,7 +11,7 @@ use bitcoin::{
     consensus::encode::serialize,
     hashes::{hash160, Hash},
     secp256k1,
-    util::{bip143::SighashComponents, psbt::PartiallySignedTransaction},
+    util::{amount::serde::as_sat, bip143::SighashComponents, psbt::PartiallySignedTransaction},
     Address, Amount, Network, OutPoint, Script, SigHash, Transaction, TxIn, TxOut, Txid,
 };
 use ecdsa_fun::{
@@ -58,10 +58,7 @@ impl FundOutput {
 pub(crate) struct FundingTransaction {
     inner: Transaction,
     fund_output_descriptor: Descriptor<bitcoin::PublicKey>,
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     fund_output_amount: Amount,
 }
 
@@ -169,10 +166,7 @@ pub(crate) struct CommitTransaction {
     output_descriptor: Descriptor<bitcoin::PublicKey>,
     time_lock: u32,
     digest: SigHash,
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     fee: Amount,
 }
 
@@ -952,15 +946,9 @@ pub(crate) fn balance(
 pub(crate) struct SpliceTransaction {
     inner: Transaction,
     fund_output_descriptor: Descriptor<bitcoin::PublicKey>,
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     amount_0: Amount,
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "bitcoin::util::amount::serde::as_sat")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "as_sat"))]
     amount_1: Amount,
 }
 

--- a/thor/src/transaction.rs
+++ b/thor/src/transaction.rs
@@ -415,6 +415,7 @@ pub(crate) enum Error {
 
 impl SplitTransaction {
     pub(crate) fn new(tx_c: &CommitTransaction, outputs: Vec<SplitOutput>) -> Result<Self, Error> {
+        debug_assert!(outputs.len() >= 2); // One for each party and optionally a PTLC.
         let total_input = tx_c.value();
         let total_output =
             Amount::from_sat(outputs.iter().map(|output| output.amount().as_sat()).sum());

--- a/thor/src/transaction/ptlc.rs
+++ b/thor/src/transaction/ptlc.rs
@@ -162,8 +162,7 @@ pub(crate) fn spend_transaction(
 ) -> Result<(Transaction, SigHash, Descriptor<bitcoin::PublicKey>)> {
     let mut Xs = [ptlc.X_funder, ptlc.X_redeemer];
     Xs.sort_by(|a, b| a.partial_cmp(b).expect("comparison is possible"));
-    let [X_0, X_1] = Xs;
-    let ptlc_output_descriptor = build_shared_output_descriptor(X_0, X_1);
+    let ptlc_output_descriptor = build_shared_output_descriptor(Xs[0].clone(), Xs[1].clone());
 
     let vout = tx_s
         .inner


### PR DESCRIPTION
Do some minor improvements to the way we handle array/vector parameters

Patch 1 - Uses an array length 2 instead of `Vec` for `FundingTransaction::new`
Patch 2 - Add `debug_assert` to check for programmer error
Patch 3 - Remove pattern matching on array

Please review patch 2 carefully to check my reasoning. Thanks.