### PR TITLE
Use 1 monero-wallet-rpc service per wallet

### DIFF
--- a/monero-harness/src/rpc/monerod.rs
+++ b/monero-harness/src/rpc/monerod.rs
@@ -79,6 +79,25 @@ impl Client {
 
         Ok(res.result.block_header)
     }
+
+    pub async fn get_block_count(&self) -> Result<u32> {
+        let request = Request::new("get_block_count", "");
+
+        let response = self
+            .inner
+            .post(self.url.clone())
+            .json(&request)
+            .send()
+            .await?
+            .text()
+            .await?;
+
+        debug!("get block count response: {}", response);
+
+        let res: Response<BlockCount> = serde_json::from_str(&response)?;
+
+        Ok(res.result.count)
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -104,4 +123,10 @@ struct GetBlockHeaderByHeight {
     block_header: BlockHeader,
     status: String,
     untrusted: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct BlockCount {
+    count: u32,
+    status: String,
 }

--- a/monero-harness/tests/client.rs
+++ b/monero-harness/tests/client.rs
@@ -17,7 +17,7 @@ async fn init_monero(tc: &'_ Cli) -> Monero<'_> {
 }
 
 #[tokio::test]
-async fn init_accounts_for_alice_and_bob() {
+async fn init_wallets_for_alice_and_bob() {
     let cli = init_cli();
     let monero = init_monero(&cli).await;
 

--- a/monero-harness/tests/wallet.rs
+++ b/monero-harness/tests/wallet.rs
@@ -6,16 +6,19 @@ use testcontainers::clients::Cli;
 async fn wallet_and_accounts() {
     let tc = Cli::default();
     let monero = Monero::new(&tc);
-    let cli = Client::localhost(monero.wallet_rpc_port);
+    let miner_wallet = Client::localhost(monero.miner_wallet_rpc_port);
 
     println!("creating wallet ...");
 
-    let _ = cli
+    let _ = miner_wallet
         .create_wallet("wallet")
         .await
         .expect("failed to create wallet");
 
-    let got = cli.get_balance(0).await.expect("failed to get balance");
+    let got = miner_wallet
+        .get_balance(0)
+        .await
+        .expect("failed to get balance");
     let want = 0;
 
     assert_that!(got).is_equal_to(want);
@@ -25,7 +28,7 @@ async fn wallet_and_accounts() {
 async fn create_account_and_retrieve_it() {
     let tc = Cli::default();
     let monero = Monero::new(&tc);
-    let cli = Client::localhost(monero.wallet_rpc_port);
+    let cli = Client::localhost(monero.miner_wallet_rpc_port);
 
     let label = "Iron Man"; // This is intentionally _not_ Alice or Bob.
 
@@ -76,7 +79,7 @@ async fn transfer_and_check_tx_key() {
     let tx_id = transfer.tx_hash;
     let tx_key = transfer.tx_key;
 
-    let cli = monero.wallet_rpc_client();
+    let cli = monero.miner_wallet_rpc_client();
     let res = cli
         .check_tx_key(&tx_id, &tx_key, &address_bob)
         .await


### PR DESCRIPTION
Instead of creating _accounts_ for Alice and Bob, we are starting a separate monero-wallet-rpc service per user. 